### PR TITLE
Solved problem after lxplus7 death

### DIFF
--- a/scripts/get_protodunehd_files.sh
+++ b/scripts/get_protodunehd_files.sh
@@ -8,6 +8,7 @@
 
 os_name=$(grep "^NAME" /etc/os-release | cut -d '=' -f 2 | tr -d '"')
 version_id=$(grep VERSION_ID /etc/os-release | cut -d '=' -f 2 | tr -d '"')
+current_dir=$(pwd)
 
 # Check if the user has provided the arguments and if not, ask for them
 if [ -n "$1" ];then
@@ -50,8 +51,9 @@ if [ -f ${rucio_paths_file} ]; then
          echo -e "\e[92mRucio loaded successfully!!\e[0m"
          else
             echo -e "\e[31mConfiguring rucio in ${os_name}: ${version_id}\e[0m"
-            if [[ $os_name == "CentOS Linux" && $version_id == 7* ]]; then
-               echo -e "\e[31mConfiguring rucio in CentOS 7\e[0m"
+            if [[ ($os_name == "CentOS Linux" || $os_name == "Scientific Linux") && $version_id == 7* ]]; then
+               wget https://authentication.fnal.gov/krb5conf/SL7/krb5.conf
+               export KRB5_CONFIG="$current_dir/krb5.conf"
                source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh
                setup python v3_9_15
                setup rucio
@@ -122,3 +124,6 @@ if [ -f ${rucio_paths_file} ]; then
          fi
       done
 fi
+
+rm -f $current_dir/krb5.conf
+kdestroy

--- a/scripts/get_rucio.py
+++ b/scripts/get_rucio.py
@@ -40,12 +40,16 @@ def main(runs):
                 subprocess.call(shlex.split(get_rucio), shell=False)
                 print(f"[WARNING] Inside lxplus7 the file will be saved in {homepath}/{one_run}.txt and not moved to {saving_path}{one_run}.txt\n")
             
-            # If not --> Run the SSH command to get the path from EVERYWHERE
+            # If not --> Run the SSH command/enter a container (needs to be already in lxplus)
             else:
-                print(f"Connecting to lxplus7 to get rucio paths :)\n")
+                # print(f"Connecting to lxplus7 to get rucio paths :)\n") # NO MORE LXPLUS7
+                # ssh_command = f'ssh -t {username}@lxplus7.cern.ch "source {current_path}/get_protodunehd_files.sh local cern {one_run}"'
                 username = os.environ['USER']
-                ssh_command = f'ssh -t {username}@lxplus7.cern.ch "source {current_path}/get_protodunehd_files.sh local cern {one_run}"'
-                subprocess.call(shlex.split(ssh_command), shell=False)
+                print(f"Starting a SL7 container to get rucio paths :)\n")
+                sl7_command = f'/cvmfs/oasis.opensciencegrid.org/mis/apptainer/current/bin/apptainer exec -f -B \
+                /cvmfs,/afs/cern.ch/user/{username[0]}/{username},/tmp,/etc/hostname,/etc/hosts,/etc/krb5.conf,/run/user/ /cvmfs/singularity.opensciencegrid.org/fermilab/fnal-dev-sl7:latest \
+                sh {current_path}/get_protodunehd_files.sh local cern {one_run}'
+                subprocess.run(shlex.split(sl7_command), shell=False)
 
                 one_run = str(one_run).zfill(6)
                 print("\n")


### PR DESCRIPTION
We now use a sl7 container to generate the rucio paths in the same way as before.
We need to download the krb5.conf at the beggining and at the end we erase it + kdestroy command.