### PR TITLE
Add the Amplitude attribute to the WfAna class

### DIFF
--- a/src/waffles/ChannelWS.py
+++ b/src/waffles/ChannelWS.py
@@ -85,23 +85,22 @@ class ChannelWS(WaveformSet):
             up to the input given to the 'analysis_label' 
             parameter. If variable is set to 'amplitude', 
             then the calibration histogram will be 
-            computed using the amplitude of the waveforms.           ## Not implemented yet
+            computed using the amplitude of the waveforms.
             The default behaviour, which is used if
             the input is different from 'integral' or
             'amplitude', is that of 'integral'.
         analysis_label : str
-            This parameter only makes a difference if
-            'compute_calib_histo' is set to True
-            and 'variable' is set to 'integral'.
-            In such case, this parameter gives the key
-            for the WfAna object within the Analyses 
+            If variable is set to 'integral' (resp.
+            'amplitude'), this parameter gives the key
+            for the WfAna object within the Analysis
             attribute of each considered waveform 
-            from where to take the integral value to 
-            add to the calibration histogram. Namely, 
-            if such WfAna object is x, then 
-            x.Result.Integral is the considered
-            integral. If 'analysis_label' is None, 
-            then the last analysis added to 
+            from where to take the integral (resp.
+            amplitude) value to add to the calibration 
+            histogram. Namely, if such WfAna object is 
+            x, then x.Result.Integral (resp. 
+            x.Result.Amplitude) is the considered
+            integral (resp. amplitude). If 'analysis_label' 
+            is None, then the last analysis added to 
             the Analyses attribute will be the used 
             one. If there is not even one analysis, 
             then an exception will be raised.

--- a/src/waffles/ChannelWSGrid.py
+++ b/src/waffles/ChannelWSGrid.py
@@ -106,8 +106,7 @@ class ChannelWSGrid:
             Check its docstring for more information.
         analysis_label : str
             This parameter only makes a difference if
-            'compute_calib_histo' is set to True
-            and 'variable' is set to 'integral'.
+            'compute_calib_histo' is set to True.
             It is given to the 'analysis_label' parameter 
             of the 'clusterize_WaveformSet' static 
             method. Check its docstring for more 
@@ -224,8 +223,7 @@ class ChannelWSGrid:
             for more information.
         analysis_label : str
             This parameter only makes a difference if
-            'compute_calib_histo' is set to True
-            and 'variable' is set to 'integral'.
+            'compute_calib_histo' is set to True.
             It is given to the 'analysis_label' parameter 
             of the ChannelWS initializer. Check its 
             docstring for more information.
@@ -397,6 +395,7 @@ class ChannelWSGrid:
                     show_baseline_limits : bool = False, 
                     show_baseline : bool = True,
                     show_general_integration_limits : bool = False,
+                    show_general_amplitude_limits : bool = False,
                     show_spotted_peaks : bool = True,
                     show_peaks_integration_limits : bool = False,
                     time_bins : int = 512,
@@ -571,6 +570,13 @@ class ChannelWSGrid:
             to True. In that case, this parameter means whether 
             to plot vertical lines framing the general 
             integration interval.
+        show_general_amplitude_limits : bool
+            This parameter only makes a difference if the
+            'mode' parameter is set to 'overlay' or 'average',
+            and the 'plot_analysis_markers' parameter is 
+            set to True. In that case, this parameter means 
+            whether to plot vertical lines framing the general 
+            amplitude interval.
         show_spotted_peaks : bool
             This parameter only makes a difference if the
             'mode' parameter is set to 'overlay' or 'average',
@@ -713,6 +719,7 @@ class ChannelWSGrid:
                                                         show_baseline_limits = show_baseline_limits,
                                                         show_baseline = show_baseline,
                                                         show_general_integration_limits = show_general_integration_limits,
+                                                        show_general_amplitude_limits = show_general_amplitude_limits,
                                                         show_spotted_peaks = show_spotted_peaks,
                                                         show_peaks_integration_limits = show_peaks_integration_limits,
                                                         analysis_label = analysis_label)
@@ -757,6 +764,7 @@ class ChannelWSGrid:
                                 show_baseline_limits = show_baseline_limits,
                                 show_baseline = show_baseline,
                                 show_general_integration_limits = show_general_integration_limits,
+                                show_general_amplitude_limits = show_general_amplitude_limits,
                                 show_spotted_peaks = show_spotted_peaks,
                                 show_peaks_integration_limits = show_peaks_integration_limits,
                                 analysis_label = analysis_label if (plot_analysis_markers and fAnalyzed) else None)

--- a/src/waffles/WaveformAdcs.py
+++ b/src/waffles/WaveformAdcs.py
@@ -522,7 +522,9 @@ class WaveformAdcs:
                                         col = col)
                     
             if show_peaks_integration_limits:   # Plot the markers for the peaks integration limits
-                pass    ## To be implemented
+                raise NotImplementedError(generate_exception_message(   1,
+                                                                        'WaveformAdcs.plot()',
+                                                                        "The 'show_peaks_integration_limits' parameter is not implemented yet."))
 
         return
     

--- a/src/waffles/WaveformAdcs.py
+++ b/src/waffles/WaveformAdcs.py
@@ -40,8 +40,8 @@ class WaveformAdcs:
                                 # The restrictions over the TimeOffset attribute
                                 # ensure that there are always at least two points
                                 # left in the [0, 1, ..., len(self.__adcs) - 1] range,
-                                # so that baselines and integrals can be computed using
-                                # points in that range.
+                                # so that baselines, integrals and amplitudes can be 
+                                # computed using points in that range.
 
     def __init__(self,  time_step_ns : float,
                         adcs : np.ndarray,
@@ -173,6 +173,8 @@ class WaveformAdcs:
                         *args,
                         int_ll : int = 0,
                         int_ul : Optional[int] = None,
+                        amp_ll : int = 0,
+                        amp_ul : Optional[int] = None,
                         overwrite : bool = False,
                         **kwargs) -> dict:
 
@@ -235,6 +237,16 @@ class WaveformAdcs:
             It is the caller's responsibility to ensure the 
             well-formedness of this input. No checks are
             performed here for this parameter.
+        amp_ll (resp. amp_ul): int
+            Given to the 'amp_ll' (resp. 'amp_ul') parameter of
+            WfAna.__init__. Iterator value for the first (resp. 
+            last) point of self.__adcs that is considered for
+            the amplitude calculation. amp_ll must be smaller 
+            than amp_ul. These limits are inclusive. If they are 
+            not defined, then the whole self.__adcs is considered.
+            It is the caller's responsibility to ensure the 
+            well-formedness of this input. No checks are
+            performed here for this parameter.
         overwrite : bool
             If True, the method will overwrite any existing
             WfAna object with the same label (key) within
@@ -262,7 +274,9 @@ class WaveformAdcs:
 
             aux = WfAna(baseline_limits,
                         int_ll,
-                        int_ul)
+                        int_ul,
+                        amp_ll,
+                        amp_ul)
             
             analyser = getattr(aux, analyser_name)
 
@@ -283,6 +297,7 @@ class WaveformAdcs:
                     show_baseline_limits : bool = False, 
                     show_baseline : bool = True,
                     show_general_integration_limits : bool = False,
+                    show_general_amplitude_limits : bool = False,
                     show_spotted_peaks : bool = True,
                     show_peaks_integration_limits : bool = False,
                     analysis_label : Optional[str] = None) -> None:
@@ -341,6 +356,11 @@ class WaveformAdcs:
             'plot_analysis_markers' is set to True. In that case,
             this parameter means whether to plot vertical lines
             framing the general integration interval.
+        show_general_amplitude_limits : bool
+            This parameter only makes a difference if
+            'plot_analysis_markers' is set to True. In that case,
+            this parameter means whether to plot vertical lines
+            framing the general amplitude interval.
         show_spotted_peaks : bool
             This parameter only makes a difference if
             'plot_analysis_markers' is set to True. In that case,
@@ -438,29 +458,52 @@ class WaveformAdcs:
                 
             if show_general_integration_limits:     # Plot the markers for the general integration limits
                                                     # These are always defined for every WfAna object
-
-                    figure.add_shape(   type = 'line',
-                                        x0 = x[aux.IntLl], y0 = 0,
-                                        x1 = x[aux.IntLl], y1 = 1,
-                                        line = dict(color = 'black',        # Properties for
-                                                    width = 1,              # the beginning of
-                                                    dash = 'solid'),        # a baseline chunk
-                                        xref = 'x',
-                                        yref = 'y domain',
-                                        row = row,
-                                        col = col)
+                figure.add_shape(   type = 'line',
+                                    x0 = x[aux.IntLl], y0 = 0,
+                                    x1 = x[aux.IntLl], y1 = 1,
+                                    line = dict(color = 'black',
+                                                width = 1,
+                                                dash = 'solid'),
+                                    xref = 'x',
+                                    yref = 'y domain',
+                                    row = row,
+                                    col = col)
                     
-                    figure.add_shape(   type = 'line',
-                                        x0 = x[aux.IntUl], y0 = 0,
-                                        x1 = x[aux.IntUl], y1 = 1,
-                                        line = dict(color = 'black',        # Properties for
-                                                    width = 1,              # the beginning of
-                                                    dash = 'solid'),        # a baseline chunk
-                                        xref = 'x',
-                                        yref = 'y domain',
-                                        row = row,
-                                        col = col)
-            
+                figure.add_shape(   type = 'line',
+                                    x0 = x[aux.IntUl], y0 = 0,
+                                    x1 = x[aux.IntUl], y1 = 1,
+                                    line = dict(color = 'black',
+                                                width = 1,
+                                                dash = 'solid'),
+                                    xref = 'x',
+                                    yref = 'y domain',
+                                    row = row,
+                                    col = col)
+                    
+            if show_general_amplitude_limits:       # Plot the markers for the general amplitude limits
+                                                    # These are always defined for every WfAna object
+                figure.add_shape(   type = 'line',
+                                    x0 = x[aux.AmpLl], y0 = 0,
+                                    x1 = x[aux.AmpLl], y1 = 1,
+                                    line = dict(color = 'green',
+                                                width = 1,
+                                                dash = 'solid'),
+                                    xref = 'x',
+                                    yref = 'y domain',
+                                    row = row,
+                                    col = col)
+                
+                figure.add_shape(   type = 'line',
+                                    x0 = x[aux.AmpUl], y0 = 0,
+                                    x1 = x[aux.AmpUl], y1 = 1,
+                                    line = dict(color = 'green',
+                                                width = 1,
+                                                dash = 'solid'),
+                                    xref = 'x',
+                                    yref = 'y domain',
+                                    row = row,
+                                    col = col)
+                        
             if show_spotted_peaks and fPeaksAreAvailable:      # Plot the markers for the spotted peaks
 
                 for peak in aux.Result.Peaks:

--- a/src/waffles/WaveformSet.py
+++ b/src/waffles/WaveformSet.py
@@ -1274,7 +1274,7 @@ class WaveformSet:
         ----------
         nrows : int
             The number of rows of the returned Map object
-        ncols : 
+        ncols : int
             The number of columns of the returned Map object
         wfs_per_axes : int
             If it is not None, then it must be a positive

--- a/src/waffles/WfAna.py
+++ b/src/waffles/WfAna.py
@@ -33,6 +33,14 @@ class WfAna:
         limits are inclusive. I.e., the points which are
         used for the integral calculation are
         wf.Adcs[IntLl - wf.TimeOffset : IntUl + 1 - wf.TimeOffset]. 
+    AmpLl (resp. AmpUl) : int
+        Stands for amplitude lower (resp. upper) limit.
+        Iterator value for the first (resp. last) point 
+        of the waveform that is considered to compute
+        the amplitude of the waveform. AmpLl must be smaller 
+        than AmpUl. These limits are inclusive. I.e., the 
+        points which are used for the amplitude calculation 
+        are wf.Adcs[AmpLl - wf.TimeOffset : AmpUl + 1 - wf.TimeOffset].
     Result : WfAnaResult
         The result of the analysis
     Passed : bool
@@ -47,7 +55,9 @@ class WfAna:
 
     def __init__(self,  baseline_limits : List[int],
                         int_ll : int,
-                        int_ul : int):
+                        int_ul : int,
+                        amp_ll : int,
+                        amp_ul : int):
         
         """
         WfAna class initializer. It is assumed that it is
@@ -61,11 +71,15 @@ class WfAna:
         baseline_limits : list of int
         int_ll : int
         int_ul : int
+        amp_ll : int
+        amp_ul : int
         """
         
         self.__baseline_limits = baseline_limits
         self.__int_ll = int_ll
         self.__int_ul = int_ul
+        self.__amp_ll = amp_ll
+        self.__amp_ul = amp_ul
         
         self.__result = None    # To be determined a posteriori 
         self.__passed = None    # by an analyser method
@@ -83,6 +97,14 @@ class WfAna:
     def IntUl(self):
         return self.__int_ul
     
+    @property
+    def AmpLl(self):
+        return self.__amp_ll
+    
+    @property
+    def AmpUl(self):
+        return self.__amp_ul
+
     @property
     def Result(self):
         return self.__result
@@ -145,6 +167,7 @@ class WfAna:
                                 baseline_rms = 1,
                                 peaks = [WfPeak(1), WfPeak(12), WfPeak(300)],
                                 integral = 10.0,
+                                amplitude = 5.0,
                                 deconvoluted_adcs = np.array([0.,-1.,1.,0.,-1.]))
         output_2 = True
         output_3 = {}
@@ -173,6 +196,8 @@ class WfAna:
             the waveform is constant and approximates its integral 
             to waveform.TimeStep_ns*np.sum( -b + waveform.Adcs[IntLl - waveform.TimeOffset : IntUl + 1 - waveform.TimeOffset]),
             where b is the computed baseline.
+            - It calculates the amplitude of 
+            waveform.Adcs[AmpLl - waveform.TimeOffset : AmpUl + 1 - waveform.TimeOffset].
 
         Note that for these computations to be well-defined, it is
         assumed that
@@ -181,6 +206,8 @@ class WfAna:
             - BaselineLimits[-1] - wf.TimeOffset <= len(wf.Adcs)
             - IntLl - wf.TimeOffset >= 0
             - IntUl - wf.TimeOffset < len(wf.Adcs)
+            - AmpLl - wf.TimeOffset >= 0
+            - AmpUl - wf.TimeOffset < len(wf.Adcs)
 
         For the sake of efficiency, these checks are not done.
         It is the caller's responsibility to ensure that these 
@@ -244,6 +271,9 @@ class WfAna:
                                 integral = waveform.TimeStep_ns*(((self.__int_ul - self.__int_ll + 1)*baseline) - np.sum(waveform.Adcs[ self.__int_ll - waveform.TimeOffset : self.__int_ul + 1 - waveform.TimeOffset])),   ## Assuming that the waveform is
                                                                                                                                                                                                                             ## inverted and using linearity
                                                                                                                                                                                                                             ## to avoid some multiplications
+                                amplitude = + np.max(waveform.Adcs[self.__amp_ll - waveform.TimeOffset : self.__amp_ul + 1 - waveform.TimeOffset]) 
+                                            - np.min(waveform.Adcs[self.__amp_ll - waveform.TimeOffset : self.__amp_ul + 1 - waveform.TimeOffset]),
+                                            
                                 deconvoluted_adcs=None)     # Not computed by this standard analyser
         
         output_2 = True         # This standard analyser does not implement a quality filter yet

--- a/src/waffles/WfAnaResult.py
+++ b/src/waffles/WfAnaResult.py
@@ -29,6 +29,8 @@ class WfAnaResult:
         The peaks which have been spotted in the waveform
     Integral : float
         The integral of the waveform Adcs
+    Amplitude : float
+        The amplitude of the waveform Adcs
     DeconvolutedAdcs : unidimensional numpy array of floats         ## For the moment, this is all of the information
         The deconvoluted waveform Adcs                              ## resulting from the deconvolution analysis that 
                                                                     ## we keep, since this is a bottleneck for such 
@@ -47,6 +49,7 @@ class WfAnaResult:
                         baseline_rms : Optional[float] = None,
                         peaks : Optional[List[WfPeak]] = None,
                         integral : Optional[float] = None,
+                        amplitude : Optional[float] = None,
                         deconvoluted_adcs : Optional[np.ndarray] = None):
         
         """
@@ -61,6 +64,7 @@ class WfAnaResult:
         baseline_rms : float
         peaks : list of WfPeak objects
         integral : float
+        amplitude : float
         deconvoluted_adcs : unidimensional numpy array of floats
 
         """
@@ -81,6 +85,7 @@ class WfAnaResult:
         self.__baseline_rms = baseline_rms
         self.__peaks = peaks
         self.__integral = integral
+        self.__amplitude = amplitude
         self.__deconvoluted_adcs = deconvoluted_adcs
 
     #Getters
@@ -107,6 +112,10 @@ class WfAnaResult:
     @property
     def Integral(self):
         return self.__integral
+    
+    @property
+    def Amplitude(self):
+        return self.__amplitude
     
     @property
     def DeconvolutedAdcs(self):


### PR DESCRIPTION
The main new feature for the users is that now calibration histograms using the amplitude rather than the integral can be computed, fitted and plotted