### PR TITLE
Fixed one bug and added one reading feature

### DIFF
--- a/src/waffles/Exceptions.py
+++ b/src/waffles/Exceptions.py
@@ -45,3 +45,14 @@ def handle_missing_data(func):
                 f" input parameters. {str(e)[1:-1]}"))
         
     return wrapper
+
+class WafflesBaseException(Exception):
+    """Exception raised when a Waffles-related error occurs.
+    Waffles custom exceptions should derive from this class."""
+    pass
+
+class NoDataInFile(WafflesBaseException):
+    """Exception raised when the file to be read is empty, 
+    or it is not empty but there is no data of the expected 
+    type (self-trigger or full-stream) in it."""
+    pass

--- a/src/waffles/data_classes/WaveformSet.py
+++ b/src/waffles/data_classes/WaveformSet.py
@@ -1,4 +1,5 @@
 import inspect
+import copy
 
 import numpy as np
 from typing import List, Dict, Callable, Optional
@@ -747,7 +748,7 @@ class WaveformSet:
         # WaveformSet.compute_mean_waveform()
         # has already checked that there is at
         # least one Waveform in this WaveformSet
-        aux = self.waveforms[0].adcs
+        aux = copy.deepcopy(self.waveforms[0].adcs)
 
         for i in range(1, len(self.__waveforms)):
             aux += self.waveforms[i].adcs

--- a/src/waffles/data_classes/WaveformSet.py
+++ b/src/waffles/data_classes/WaveformSet.py
@@ -1,15 +1,12 @@
 import inspect
 
 import numpy as np
-from typing import Tuple, List, Dict, Callable, Optional
-from plotly import graph_objects as pgo
-from plotly import subplots as psu
+from typing import List, Dict, Callable, Optional
 
 from waffles.data_classes.WaveformAdcs import WaveformAdcs
 from waffles.data_classes.WfAna import WfAna
 from waffles.data_classes.IPDict import IPDict
 
-import waffles.utils.numerical_utils as wun
 import waffles.utils.filtering_utils as wuf
 
 from waffles.Exceptions import GenerateExceptionMessage

--- a/src/waffles/input/pickle_file_to_WaveformSet.py
+++ b/src/waffles/input/pickle_file_to_WaveformSet.py
@@ -2,7 +2,7 @@ import os
 import _pickle as pickle    # Making sure that cPickle is used
 
 from waffles.data_classes.WaveformSet import WaveformSet
-from waffles.Exceptions import generate_exception_message
+from waffles.Exceptions import GenerateExceptionMessage
 
 def pickle_file_to_WaveformSet(
         path_to_pickle_file : str,

--- a/src/waffles/input/raw_root_reader.py
+++ b/src/waffles/input/raw_root_reader.py
@@ -21,7 +21,7 @@ from typing import List, Optional
 import waffles.utils.check_utils as wuc
 import waffles.input.input_utils as wii
 from waffles.data_classes.WaveformSet import WaveformSet
-from waffles.Exceptions import GenerateExceptionMessage
+import waffles.Exceptions as we
 
 def WaveformSet_from_root_files(
     library: str,
@@ -112,7 +112,7 @@ def WaveformSet_from_root_files(
         folder = Path(folderpath)
         if not folder.is_dir():
 
-            raise Exception(GenerateExceptionMessage(
+            raise Exception(we.GenerateExceptionMessage(
                 1,
                 'WaveformSet_from_root_files()',
                 f"The given folderpath ({folderpath})"
@@ -134,7 +134,7 @@ def WaveformSet_from_root_files(
                                 filepath)]
         
     if len(valid_filepaths) == 0:
-        raise Exception(GenerateExceptionMessage(
+        raise Exception(we.GenerateExceptionMessage(
             2,
             'WaveformSet_from_root_files()',
             f"No valid ROOT files were found in the "
@@ -345,13 +345,13 @@ def WaveformSet_from_root_file(
     """
 
     if not wuc.fraction_is_well_formed(start_fraction, stop_fraction):
-        raise Exception(GenerateExceptionMessage(
+        raise Exception(we.GenerateExceptionMessage(
             1,
             'WaveformSet_from_root_file()',
             f"Fraction limits are not well-formed."))
     
     if library not in ['uproot', 'pyroot']:
-        raise Exception(GenerateExceptionMessage(
+        raise Exception(we.GenerateExceptionMessage(
             2,
             'WaveformSet_from_root_file()',
             f"The given library ({library}) is not supported."))
@@ -413,7 +413,7 @@ def WaveformSet_from_root_file(
     # That's why we carry both parameters until then.
 
     if len(aux) == 0:
-        raise Exception(GenerateExceptionMessage(
+        raise Exception(we.GenerateExceptionMessage(
             3,
             'WaveformSet_from_root_file()',
             f"No waveforms of the specified type "

--- a/src/waffles/input/raw_root_reader.py
+++ b/src/waffles/input/raw_root_reader.py
@@ -413,7 +413,7 @@ def WaveformSet_from_root_file(
     # That's why we carry both parameters until then.
 
     if len(aux) == 0:
-        raise Exception(we.GenerateExceptionMessage(
+        raise we.NoDataInFile(we.GenerateExceptionMessage(
             3,
             'WaveformSet_from_root_file()',
             f"No waveforms of the specified type "

--- a/src/waffles/persistence/persistence_utils.py
+++ b/src/waffles/persistence/persistence_utils.py
@@ -2,7 +2,7 @@ import os
 import _pickle as pickle    # Making sure that cPickle is used
 
 from waffles.data_classes.WaveformSet import WaveformSet
-from waffles.Exceptions import generate_exception_message
+from waffles.Exceptions import GenerateExceptionMessage
 
 def WaveformSet_to_file(
         waveform_set : WaveformSet,


### PR DESCRIPTION
The bug had to do with the overwriting of the first waveform in a WaveformSet when calling WaveformSet.compute_mean_waveform() with its default behaviour. The feature has to do with the WaveformSet_from_root_files() function. Before, its execution was stopped if any of the provided files did not have waveforms of the specified type (self-trigger or full-stream). Now, it selectively reads and merge the ones that have waveforms of the given type.