### PR TITLE
Fragment Content Checking

### DIFF
--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -367,6 +367,8 @@ def WaveformSet_from_hdf5_file(filepath : str,
                 print(f"Empty fragment:\n {frag}\n{trig}\n{r}\n{gid}")
                 continue
             
+            if frag.get_fragment_type() == FragmentType.kDAPHNEStream and not read_full_streaming_data:
+                continue
 
             trig = h5_file.get_trh(r)
 

--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -363,6 +363,9 @@ def WaveformSet_from_hdf5_file(filepath : str,
                 #print(traceback.format_exc())
                 continue
                 
+            if frag.get_data_size() == 0:
+                print(f"Empty fragment:\n {frag}\n{trig}\n{r}\n{gid}")
+                continue
             
 
             trig = h5_file.get_trh(r)

--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -99,7 +99,7 @@ def extract_fragment_info(frag, trig):
         adcs = np_array_adc(frag)
         channels = np_array_channels(frag)
 
-    elif fragType == 13:  # For full_stream
+    elif fragType == FragmentType.kDAPHNEStream:  # For full_stream
         trigger = 'full_stream'
         timestamps = np_array_timestamp_stream(frag)
         adcs = np_array_adc_stream(frag)


### PR DESCRIPTION
## Empty Fragment Check
If the fragment to be extracted is empty, report it and skip. This should help to handle problems further down if there is unexpected behavior within the file.

## DAPHNEStream Fragment Check
If the fragment is a `kDAPHNEStream` and `read_full_streaming_data` is false, then these fragments should be skipped. I added this check before further processing to prevent unnecessary work.

## Testing
I'm not very familiar with the workflow or usage of `waffles`, so I have not done any testing. If a thorough test needs to be done by me, then I can do this at a later time.