### PR TITLE
Check For DAPHNE Fragment.

### DIFF
--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -370,7 +370,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
             if read_full_streaming_data and frag.get_fragment_type() == FragmentType.kDAPHNE:
                 continue
             
-            if frag.get_fragment_type() == FragmentType.kDAPHNEStream and not read_full_streaming_data:
+            if not read_full_streaming_data and frag.get_fragment_type() == FragmentType.kDAPHNEStream:
                 continue
 
             trig = h5_file.get_trh(r)

--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -366,6 +366,9 @@ def WaveformSet_from_hdf5_file(filepath : str,
             if frag.get_data_size() == 0:
                 print(f"Empty fragment:\n {frag}\n{trig}\n{r}\n{gid}")
                 continue
+
+            if read_full_streaming_data and frag.get_fragment_type() == FragmentType.kDAPHNE:
+                continue
             
             if frag.get_fragment_type() == FragmentType.kDAPHNEStream and not read_full_streaming_data:
                 continue


### PR DESCRIPTION
## DAPHNE Fragment Check
If the fragment is a `kDAPHNE` and `read_full_streaming_data` is true, then the `kDAPHNE` fragment is skipped. Only `kDAPHNEStream` fragment should then be processed for this file.