### PR TITLE
Remove Early `trig` Reference.

### DIFF
--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -359,12 +359,12 @@ def WaveformSet_from_hdf5_file(filepath : str,
                 if (not hdf5_check_allowed_ids(frag, allowed_ids)):
                     continue
             except Exception as e:
-                print(f"Corrupted fragment:\n {frag}\n{trig}\n{r}\n{gid}")
+                print(f"Corrupted fragment:\n {frag}\n{r}\n{gid}")
                 #print(traceback.format_exc())
                 continue
                 
             if frag.get_data_size() == 0:
-                print(f"Empty fragment:\n {frag}\n{trig}\n{r}\n{gid}")
+                print(f"Empty fragment:\n {frag}\n{r}\n{gid}")
                 continue
 
             if read_full_streaming_data and frag.get_fragment_type() == FragmentType.kDAPHNE:


### PR DESCRIPTION
Debug prints used `trig` before assignment.