### PR TITLE
Enable the truncation of every waveform in a WaveformSet

### DIFF
--- a/src/waffles/data_classes/BasicWfAna.py
+++ b/src/waffles/data_classes/BasicWfAna.py
@@ -133,7 +133,7 @@ class BasicWfAna(WfAna):
 
         Parameters
         ----------
-        waveform : WaveformAdcs
+        waveform: WaveformAdcs
             The WaveformAdcs object which will be analysed
 
         Returns
@@ -212,11 +212,11 @@ class BasicWfAna(WfAna):
 
         Parameters
         ----------
-        input_parameters : IPDict
+        input_parameters: IPDict
             The input parameters to be checked. It is the IPDict
             that can be potentially given to BasciWfAna.__init__
             to instantiate a BasicWfAna object.
-        points_no : int
+        points_no: int
             The number of points in any waveform that could be
             analysed. It is assumed to be the same for all the
             waveforms.

--- a/src/waffles/data_classes/ChannelMap.py
+++ b/src/waffles/data_classes/ChannelMap.py
@@ -81,7 +81,7 @@ class ChannelMap(Map):
 
         Returns
         -------
-        output : tuple of ( bool, tuple of (int, int, ), )
+        output: tuple of ( bool, tuple of (int, int, ), )
         """
 
         for i in range(self.rows):

--- a/src/waffles/data_classes/Map.py
+++ b/src/waffles/data_classes/Map.py
@@ -31,8 +31,8 @@ class Map:
     """
 
     def __init__(
-        self : int,
-        rows : int,
+        self: int,
+        rows: int,
         columns: int,
         type_: type,
         data: Optional[List[List[Any]]] = None

--- a/src/waffles/data_classes/PeakFindingWfAna.py
+++ b/src/waffles/data_classes/PeakFindingWfAna.py
@@ -111,15 +111,15 @@ class PeakFindingWfAna(BasicWfAna):
 
         Parameters
         ----------
-        waveform : WaveformAdcs
+        waveform: WaveformAdcs
             The WaveformAdcs object which will be analysed
-        return_peaks_properties : bool
+        return_peaks_properties: bool
             If True, then this method returns information about
             the spotted-peaks properties.
 
         Returns
         ----------
-        output : dict
+        output: dict
             If return_peaks_properties is False, then this
             dictionary is empty. If return_peaks_properties is
             True, then this is a dictionary containing the
@@ -172,11 +172,11 @@ class PeakFindingWfAna(BasicWfAna):
 
         Parameters
         ----------
-        input_parameters : IPDict
+        input_parameters: IPDict
             The input parameters to be checked. It is the IPDict
             that can be potentially given to BasciWfAna.__init__
             to instantiate a BasicWfAna object.
-        points_no : int
+        points_no: int
             The number of points in any Waveform that could be
             analysed. It is assumed to be the same for all the
             waveforms.

--- a/src/waffles/data_classes/UniqueChannel.py
+++ b/src/waffles/data_classes/UniqueChannel.py
@@ -4,9 +4,9 @@ class UniqueChannel:
 
     Attributes
     ----------
-    endpoint : int
+    endpoint: int
         An endpoint value
-    channel : int
+    channel: int
         A channel value
 
     Methods

--- a/src/waffles/data_classes/Waveform.py
+++ b/src/waffles/data_classes/Waveform.py
@@ -12,27 +12,27 @@ class Waveform(WaveformAdcs):
 
     Attributes
     ----------
-    timestamp : int
+    timestamp: int
         The timestamp value for this Waveform
-    time_step_ns : float (inherited from WaveformAdcs)
-    daq_window_timestamp : int
+    time_step_ns: float (inherited from WaveformAdcs)
+    daq_window_timestamp: int
         The timestamp value for the DAQ window in which
         this Waveform was acquired
-    adcs : unidimensional numpy array of integers
+    adcs: unidimensional numpy array of integers
     (inherited from WaveformAdcs)
-    run_number : int
+    run_number: int
         Number of the run from which this Waveform was
         acquired
-    record_number : int
+    record_number: int
         Number of the record within which this Waveform
         was acquired
-    endpoint : int
+    endpoint: int
         Endpoint number from which this Waveform was
         acquired
-    channel : int
+    channel: int
         Channel number for this Waveform
-    time_offset : int (inherited from WaveformAdcs)
-    analyses : OrderedDict of WfAna objects 
+    time_offset: int (inherited from WaveformAdcs)
+    analyses: OrderedDict of WfAna objects 
     (inherited from WaveformAdcs)
 
     Methods
@@ -56,19 +56,19 @@ class Waveform(WaveformAdcs):
 
         Parameters
         ----------
-        timestamp : int
-        time_step_ns : float
+        timestamp: int
+        time_step_ns: float
             It is given to the 'time_step_ns' parameter of
             the base class initializer.
-        daq_window_timestamp : int
-        adcs : unidimensional numpy array of integers
+        daq_window_timestamp: int
+        adcs: unidimensional numpy array of integers
             It is given to the 'adcs' parameter of the base
             class initializer.
-        run_number : int
-        record_number : int
-        endpoint : int
-        channel : int
-        time_offset : int
+        run_number: int
+        record_number: int
+        endpoint: int
+        channel: int
+        time_offset: int
             It is given to the 'time_offset' parameter of the
             base class initializer. It must be semipositive
             and smaller than len(self.__adcs)-1. Its default

--- a/src/waffles/data_classes/Waveform.py
+++ b/src/waffles/data_classes/Waveform.py
@@ -32,6 +32,15 @@ class Waveform(WaveformAdcs):
     channel: int
         Channel number for this Waveform
     time_offset: int (inherited from WaveformAdcs)
+    starting_tick: int
+        The iterator value (zero-indexed) for the
+        first point of this Waveform, with respect
+        to the full acquired waveform. P.e. if this
+        Waveform is the result of eliminating the
+        first two points of a certain waveform,
+        then this attribute equals 2. If no initial
+        points have been truncated, then this
+        attribute equals 0.
     analyses: OrderedDict of WfAna objects 
     (inherited from WaveformAdcs)
 
@@ -50,7 +59,8 @@ class Waveform(WaveformAdcs):
         record_number: int,
         endpoint: int,
         channel: int,
-        time_offset: int = 0):
+        time_offset: int = 0,
+        starting_tick: int = 0):
         """
         Waveform class initializer
 
@@ -73,6 +83,7 @@ class Waveform(WaveformAdcs):
             base class initializer. It must be semipositive
             and smaller than len(self.__adcs)-1. Its default
             value is 0.
+        starting_tick: int
         """
 
         # Shall we add add type checks here?
@@ -83,6 +94,7 @@ class Waveform(WaveformAdcs):
         self.__record_number = record_number
         self.__endpoint = endpoint
         self.__channel = channel
+        self.__starting_tick = starting_tick
 
         # Do we need to add trigger primitives as attributes?
 
@@ -115,6 +127,10 @@ class Waveform(WaveformAdcs):
     @property
     def channel(self):
         return self.__channel
+
+    @property
+    def starting_tick(self):
+        return self.__starting_tick
 
 #   #Setters
 #   @timestamp.setter

--- a/src/waffles/data_classes/Waveform.py
+++ b/src/waffles/data_classes/Waveform.py
@@ -144,6 +144,37 @@ class Waveform(WaveformAdcs):
 # through Waveform.__init__. Here's an example
 # of what a setter would look like, though.
 
+    # Overrides WaveformAdcs.__slice_adcs()
+    def __slice_adcs(
+        self,
+        start: int,
+        end: int
+    ) -> None:
+        """This method is not intended for user usage.
+        No well-formedness checks are performed here.
+        This method slices the self.__adcs attribute
+        array to self.__adcs[start:end] and sets
+        the self.__starting_tick attribute to start.
+        This method applies the change in place.
+
+        Parameters
+        ----------
+        start: int
+            Iterator value for the (inclusive) start of
+            the slice
+        end: int
+            Iterator value for the (exclusive) end of
+            the slice
+
+        Returns
+        ----------
+        None
+        """
+
+        self.__starting_tick = start
+        super()._WaveformAdcs__slice_adcs(start, end)
+        return
+
     def get_global_channel(self):
         """
         Returns

--- a/src/waffles/data_classes/WaveformAdcs.py
+++ b/src/waffles/data_classes/WaveformAdcs.py
@@ -148,7 +148,7 @@ class WaveformAdcs:
         """This method is not intended for user usage.
         No well-formedness checks are performed here.
         This method slices the self.__adcs attribute
-        array to the [start, end] interval. This method
+        array to self.__adcs[start, end]. This method
         applies the change in place.
 
         Parameters

--- a/src/waffles/data_classes/WaveformAdcs.py
+++ b/src/waffles/data_classes/WaveformAdcs.py
@@ -61,9 +61,9 @@ class WaveformAdcs:
 
         Parameters
         ----------
-        time_step_ns : float
-        adcs : unidimensional numpy array of integers
-        time_offset : int
+        time_step_ns: float
+        adcs: unidimensional numpy array of integers
+        time_offset: int
             It must be semipositive and smaller than
             len(self.__adcs)-1. It is set to 0 by
             default.

--- a/src/waffles/data_classes/WaveformAdcs.py
+++ b/src/waffles/data_classes/WaveformAdcs.py
@@ -112,7 +112,6 @@ class WaveformAdcs:
 #       self.__time_step_ns = input
 #       return
 
-
     def __set_time_offset(self, input: float) -> None:
         """This method is not intended for user usage. It 
         is a setter for the time_offset attribute.
@@ -141,29 +140,34 @@ class WaveformAdcs:
 
         return
 
-    def __truncate_adcs(
-        self, 
-        number_of_points_to_keep: int
+    def __slice_adcs(
+        self,
+        start: int,
+        end: int
     ) -> None:
-        """This method is not intended for user usage. It 
-        truncates the self.__adcs attribute array to the 
-        first 'number_of_points_to_keep' points.
+        """This method is not intended for user usage.
+        No well-formedness checks are performed here.
+        This method slices the self.__adcs attribute
+        array to the [start, end] interval. This method
+        applies the change in place.
 
         Parameters
         ----------
-        number_of_points_to_keep: int
+        start: int
+            Iterator value for the (inclusive) start of
+            the slice
+        end: int
+            Iterator value for the (exclusive) end of
+            the slice
 
         Returns
         ----------
         None
         """
 
-        # Numpy handles the case where number_of_points_to_keep
-        # is greater than the length of self.__adcs.
-        self.__adcs = self.__adcs[:number_of_points_to_keep]
+        self.__adcs = self.__adcs[start:end]
         return
         
-
     def confine_iterator_value(self, input: int) -> int:
         """Confines the input integer to the range [0, len(self.__adcs) - 1].
         I.e returns 0 if input is negative, returns input if input belongs

--- a/src/waffles/data_classes/WaveformSet.py
+++ b/src/waffles/data_classes/WaveformSet.py
@@ -897,6 +897,17 @@ class WaveformSet:
             return True
         else:
             return False
+        
+    def reset_mean_waveform(self) -> None:
+        """This method resets the self.__mean_adcs
+        and the self.__mean_adcs_idcs attributes
+        of this WaveformSet object to None.
+        """
+
+        self.__mean_adcs = None
+        self.__mean_adcs_idcs = None
+
+        return
 
     def filter(
         self, 

--- a/src/waffles/input/input_utils.py
+++ b/src/waffles/input/input_utils.py
@@ -550,7 +550,11 @@ def __build_waveforms_list_from_root_file_using_uproot(
                     current_record_array[i],
                     endpoint,
                     channel,
-                    time_offset=0))
+                    time_offset=0,
+                    # Open task: Implement the truncation of the 
+                    # Waveform objects at this level (reading 
+                    # from a ROOT file using uproot)
+                    starting_tick=0))
     else:
 
         raw_time_offsets = []
@@ -596,7 +600,11 @@ def __build_waveforms_list_from_root_file_using_uproot(
                     current_record_array[i],
                     endpoint,
                     channel,
-                    time_offset=0))
+                    time_offset=0,
+                    # Open task: Implement the truncation of the Waveform
+                    # objects at this level (reading from a ROOT file
+                    # using uproot)
+                    starting_tick=0))
 
                 raw_time_offsets.append(
                     int(current_timestamp_array[i]) - int(current_daq_timestamp_array[i]))
@@ -765,7 +773,11 @@ def __build_waveforms_list_from_root_file_using_pyroot(
                 record_address[0],
                 endpoint,
                 channel,
-                time_offset=0))
+                time_offset=0,
+                # Open task: Implement the truncation of the Waveform
+                # objects at this level (reading from a ROOT file
+                # using pyroot)
+                starting_tick=0))
     else:
 
         raw_time_offsets = []
@@ -787,7 +799,11 @@ def __build_waveforms_list_from_root_file_using_pyroot(
                 record_address[0],
                 endpoint,
                 channel,
-                time_offset=0))
+                time_offset=0,
+                # Open task: Implement the truncation of the Waveform
+                # objects at this level (reading from a ROOT file
+                # using pyroot)
+                starting_tick=0))
 
             raw_time_offsets.append(
                 int(timestamp_address[0]) - int(daq_timestamp_address[0]))

--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -410,7 +410,10 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                                   r[0],
                                                   endpoint,
                                                   ch,
-                                                  time_offset=0))
+                                                  time_offset=0,
+                                                  # Open task: Implement the truncation of the Waveform
+                                                  # objects at this level (reading from an HDF5 file)
+                                                  starting_tick=0))
                     wvfm_index += 1
                     if wvfm_index >= wvfm_count:
 

--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -423,8 +423,10 @@ def WaveformSet_from_hdf5_file(filepath : str,
                             ).min()
 
                             for wf in waveforms:
-                                wf._WaveformAdcs__truncate_adcs(
-                                    minimum_length)
+                                wf._WaveformAdcs__slice_adcs(
+                                    0,
+                                    minimum_length
+                                )
 
                         return WaveformSet(*waveforms)
                     
@@ -434,7 +436,9 @@ def WaveformSet_from_hdf5_file(filepath : str,
         ).min()
 
         for wf in waveforms:
-            wf._WaveformAdcs__truncate_adcs(
-                minimum_length)
+            wf._WaveformAdcs__slice_adcs(
+                0,
+                minimum_length
+            )
 
     return WaveformSet(*waveforms)

--- a/src/waffles/input/raw_root_reader.py
+++ b/src/waffles/input/raw_root_reader.py
@@ -479,6 +479,9 @@ def WaveformSet_from_root_file(
         minimum_length = np.array([len(wf.adcs) for wf in waveforms]).min()
 
         for wf in waveforms:
-            wf._WaveformAdcs__truncate_adcs(minimum_length)
+            wf._WaveformAdcs__slice_adcs(
+                0,
+                minimum_length
+            )
 
     return WaveformSet(*waveforms)

--- a/src/waffles/plotting/plot.py
+++ b/src/waffles/plotting/plot.py
@@ -11,6 +11,7 @@ from waffles.data_classes.Map import Map
 
 import waffles.plotting.plot_utils as wpu
 import waffles.utils.numerical_utils as wun
+import waffles.utils.wf_maps_utils as wuw
 
 from waffles.Exceptions import GenerateExceptionMessage
 
@@ -666,7 +667,8 @@ def plot_WaveformSet(
                 'plot_WaveformSet()',
                 'The number of waveforms per axes must be positive.'))
 
-        data_of_map_of_wf_idcs = waveform_set.get_map_of_wf_idcs(   
+        data_of_map_of_wf_idcs = wuw.get_map_of_wf_idcs(   
+            waveform_set,
             nrows,
             ncols,
             wfs_per_axes=wfs_per_axes).data

--- a/src/waffles/utils/filtering_utils.py
+++ b/src/waffles/utils/filtering_utils.py
@@ -263,7 +263,7 @@ def truncate_waveforms_in_WaveformSet(
     # input WaveformSet is preserved, so there's no need to
     # call input_WaveformSet.check_length_homogeneity()
     for wf in input_WaveformSet.waveforms:
-        wf._WaveformAdcs__slice_adcs(
+        wf._Waveform__slice_adcs(
             starting_tick,
             ending_tick_
         )

--- a/src/waffles/utils/filtering_utils.py
+++ b/src/waffles/utils/filtering_utils.py
@@ -1,4 +1,5 @@
 import inspect
+from typing import Optional
 
 from waffles.data_classes.WaveformAdcs import WaveformAdcs
 from waffles.data_classes.Waveform import Waveform
@@ -151,3 +152,126 @@ def match_endpoint_and_channel(
     """
 
     return waveform.endpoint == endpoint and waveform.channel == channel
+
+
+def truncate_waveforms_in_WaveformSet(
+    # Avoid circular import
+    input_WaveformSet: 'WaveformSet',
+    starting_tick: int,
+    points_number: Optional[int] = None,
+    ending_tick: Optional[int] = None,
+) -> None:
+    """This function gets a WaveformSet object and truncates
+    all the Waveform objects in its 'waveforms' attribute
+    according to the given starting_tick and 
+    points_number/ending_tick. This function preserves the
+    length homogeneity of the Waveform objects in the input
+    WaveformSet object. These changes are applied in place.
+    I.e. if the original data should be preserved, it is the
+    user's responsiblity to have performed a deep copy of
+    the input WaveformSet object before calling this function.
+    
+    Parameters
+    ----------
+    input_WaveformSet: WaveformSet
+        The WaveformSet object whose Waveform objects will be
+        truncated
+    starting_tick: int
+        The starting tick of the truncation. It must belong to
+        the [0, input_WaveformSet.points_per_wf - 1]
+    points_number: int
+        If it is defined, then the input given to the
+        ending_tick parameter is ignored and the Waveform
+        objects in the input WaveformSet object will be
+        truncated to have this number of points as of the
+        specified starting tick. It must belong to the 
+        [1, input_WaveformSet.points_per_wf - starting_tick]
+        range. Either this parameter or the ending_tick
+        parameter must be defined, otherwise an exception
+        is raised.
+    ending_tick: int
+        If it is defined and points_number is not, then the
+        Waveform objects in the input WaveformSet object will
+        be truncated up to this tick. This limit is exclusive.
+        It must belong to the
+        [starting_tick + 1, input_WaveformSet.points_per_wf]
+        range.
+    """
+
+    if starting_tick < 0 or \
+        starting_tick >= input_WaveformSet.points_per_wf:
+
+        raise Exception(
+            GenerateExceptionMessage(
+                1,
+                'truncate_waveforms_in_WaveformSet()',
+                f"The given starting_tick ({starting_tick}) must belong "
+                f"to the [0, {input_WaveformSet.points_per_wf - 1}] range."
+            )
+        )
+    
+    # Use the points_number parameter if it is defined
+    if points_number is not None:
+        if points_number < 1 or \
+            points_number > input_WaveformSet.points_per_wf - starting_tick:
+
+            raise Exception(
+                GenerateExceptionMessage(
+                    2,
+                    'truncate_waveforms_in_WaveformSet()',
+                    f"The given points_number ({points_number}) must belong "
+                    f"to the [1, {input_WaveformSet.points_per_wf - starting_tick}]"
+                    " range."
+                )
+            )
+        
+        # Not adding a -1 here because ending_tick_ is exclusive
+        ending_tick_ = starting_tick + points_number
+
+    # Use the ending_tick parameter if
+    # points_number is not defined
+    elif ending_tick is not None:
+        if ending_tick <= starting_tick or \
+            ending_tick > input_WaveformSet.points_per_wf: 
+
+            raise Exception(
+                GenerateExceptionMessage(
+                    3,
+                    'truncate_waveforms_in_WaveformSet()',
+                    f"The given ending_tick ({ending_tick}) must belong to "
+                    f"the [{starting_tick + 1}, {input_WaveformSet.points_per_wf}]"
+                    " range."
+                )
+            )
+
+        ending_tick_ = ending_tick
+
+    # If neither points_number nor ending_tick
+    # is defined, raise an exception
+    else:
+        raise Exception(
+            GenerateExceptionMessage(
+                4,
+                'truncate_waveforms_in_WaveformSet()',
+                "Either the points_number or "
+                "the ending_tick parameter must be defined."
+            )
+        )
+
+    # Looping over every waveform for the slice ensures that
+    # the length homogeneity of the Waveform objects in the
+    # input WaveformSet is preserved, so there's no need to
+    # call input_WaveformSet.check_length_homogeneity()
+    for wf in input_WaveformSet.waveforms:
+        wf._WaveformAdcs__slice_adcs(
+            starting_tick,
+            ending_tick_
+        )
+
+    # Update the points_per_wf attribute which has no setter method
+    input_WaveformSet._WaveformSet__points_per_wf = ending_tick_ - starting_tick
+
+    # Reset the mean waveform information
+    input_WaveformSet.reset_mean_waveform()
+
+    return


### PR DESCRIPTION
The function `truncate_waveforms_in_WaveformSet()` added in `src/waffles/utils/filtering_utils.py` allows the truncation of every waveform in a `WaveformSet`. When the waveforms are truncated, their `starting_tick` attribute is updated accordingly. This new attribute of the `Waveform` class is also introduced in this PR. 