### PR TITLE
Add option for different detectors in hdf5 reader

### DIFF
--- a/src/waffles/input/raw_hdf5_reader.py
+++ b/src/waffles/input/raw_hdf5_reader.py
@@ -183,6 +183,7 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
                                 subsample : int = 1,
                                 wvfm_count : int = 1e9,
                                 allowed_endpoints: Optional[list] = [],
+                                det : str = 'HD_PDS'
                                 ) -> WaveformSet:
     """
     Alternative initializer for a WaveformSet object that reads waveforms directly from hdf5 files.
@@ -227,6 +228,9 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
     allowed_endpoints : list(str)
         List of endpoints that will be decoded. Leave empty for getting all
         endpoints. Avoid reading waveforms unnecessarily 
+    det : str
+        String that corresponds to the detector type.
+        Examples: HD_PDS, VD_Membrane_PDS, VD_Cathode_PDS
     """
     if folderpath is not None:
 
@@ -256,6 +260,7 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
                 subsample,
                 wvfm_count,
                 allowed_endpoints,
+                det
             )
 
         except Exception as error:
@@ -278,6 +283,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                subsample : int = 1,
                                wvfm_count : int = 1e9,
                                allowed_endpoints: Optional[list] = [],
+                               det : str = 'HD_PDS'
                                ) -> WaveformSet:
     """
     Alternative initializer for a WaveformSet object that reads waveforms directly from hdf5 files.
@@ -316,16 +322,19 @@ def WaveformSet_from_hdf5_file(filepath : str,
     allowed_endpoints : list(str)
         List of endpoints that will be decoded. Leave empty for getting all
         endpoints. Avoid reading waveforms unnecessarily 
+    det : str
+        String that corresponds to the detector type.
+        Examples: HD_PDS, VD_Membrane_PDS, VD_Cathode_PDS
     """
 
-    if "/eos" not in filepath:
+    if "/eos" not in filepath and False:
         print("Using XROOTD")
 
         subprocess.call(shlex.split(f"xrdcp {filepath} /tmp/."), shell=False)
         filepath = f"/tmp/{filepath.split('/')[-1]}"
 
     h5_file = HDF5RawDataFile(filepath)
-    det        = 'HD_PDS'
+    #det        = 'HD_PDS'
     run_date   = h5_file.get_attribute('creation_timestamp')
     run_id     = filepath.split('/')[-1].split('_')[3]
     run_flow   = filepath.split('/')[-1].split('_')[4]


### PR DESCRIPTION
Added a command line option to use different detectors in the hdf5 reader (i.e. VD). Default is `HD_PDS`, other options right now are `VD_Membrane_PDS` and `VD_Cathode_PDS`.

I also added the det-specific `map_id`. The values of VD are preliminary and probably will change. This will be updated in a later PR once we figure it out.