### PR TITLE
Fix bug related to ROOT references

### DIFF
--- a/src/waffles/input_output/input_utils.py
+++ b/src/waffles/input_output/input_utils.py
@@ -8,7 +8,7 @@ try:
     ROOT_IMPORTED = True
 except ImportError:
     print(
-        "[raw_ROOT_reader.py]: Could not import ROOT module. "
+        "[input_utils.py]: Could not import ROOT module. "
         "'pyroot' library options will not be available."
     )
     ROOT_IMPORTED = False

--- a/src/waffles/input_output/input_utils.py
+++ b/src/waffles/input_output/input_utils.py
@@ -21,10 +21,10 @@ from waffles.Exceptions import GenerateExceptionMessage
 
 
 def find_ttree_in_root_tfile(
-    file: Union[uproot.ReadOnlyDirectory, ROOT.TFile],
+    file: Union[uproot.ReadOnlyDirectory, 'ROOT.TFile'],
     TTree_pre_name: str,
     library: str
-) -> Union[uproot.TTree, ROOT.TTree]:
+) -> Union[uproot.TTree, 'ROOT.TTree']:
     """This function returns the first object found in the given
     ROOT file whose name starts with the string given to the
     'TTree_pre_name' parameter and which is a TTree object,
@@ -100,10 +100,10 @@ def find_ttree_in_root_tfile(
 
 
 def find_tbranch_in_root_ttree(
-    tree: Union[uproot.TTree, ROOT.TTree],
+    tree: Union[uproot.TTree, 'ROOT.TTree'],
     TBranch_pre_name: str,
     library: str
-) -> Tuple[Union[uproot.TBranch, ROOT.TBranch], str]:
+) -> Tuple[Union[uproot.TBranch, 'ROOT.TBranch'], str]:
     """This function returns the first TBranch found in 
     the given ROOT TTree whose name starts with the string
     given to the 'TBranch_pre_name' parameter, and the
@@ -260,7 +260,7 @@ def root_to_array_type_code(input: str) -> str:
 
 
 def get_1d_array_from_pyroot_tbranch(
-    tree: ROOT.TTree,
+    tree: 'ROOT.TTree',
     branch_name: str,
     i_low: int = 0,
     i_up: Optional[int] = None,
@@ -619,8 +619,8 @@ def __build_waveforms_list_from_root_file_using_uproot(
 
 def __build_waveforms_list_from_root_file_using_pyroot(
     idcs_to_retrieve: np.ndarray,
-    bulk_data_tree: ROOT.TTree,
-    meta_data_tree: ROOT.TTree,
+    bulk_data_tree: 'ROOT.TTree',
+    meta_data_tree: 'ROOT.TTree',
     set_offset_wrt_daq_window: bool = False,
     first_wf_index: int = 0,
     subsample: int = 1,
@@ -864,7 +864,7 @@ def __read_metadata_from_root_file_using_uproot(
 
 
 def __read_metadata_from_root_file_using_pyroot(
-    meta_data_tree: ROOT.TTree
+    meta_data_tree: 'ROOT.TTree'
 ) -> Tuple[Union[int, float]]:
     """This is a helper function which must only be called by
     the __build_waveforms_list_from_root_file_using_pyroot()

--- a/src/waffles/input_output/raw_root_reader.py
+++ b/src/waffles/input_output/raw_root_reader.py
@@ -10,7 +10,7 @@ try:
     ROOT_IMPORTED = True
 except ImportError: 
     print(
-        "[raw_ROOT_reader.py]: Could not import ROOT module. "
+        "[raw_root_reader.py]: Could not import ROOT module. "
         "'pyroot' library options will not be available."
     )
     ROOT_IMPORTED = False


### PR DESCRIPTION
In `src/waffles/input_output/input_utils.py` and `src/waffles/input_output/raw_root_reader.py`, the pyROOT module is imported only if a ROOT installation is found, which is decided at run time. However, as part of the type hinting there are unconditional references to ROOT types. These references have been substituted with forward references, which are compatible with the typing module mypy.

Note that this is not a fix to the segmentation fault previously encountered. If a ROOT installation is found and the pyROOT module is imported, the segfault may still occur.