### PR TITLE
Delete temporal files copied with XRootD after WaveformSet creation

### DIFF
--- a/src/waffles/Exceptions.py
+++ b/src/waffles/Exceptions.py
@@ -88,3 +88,7 @@ class IncompatibleInput(WafflesBaseException):
     if some of the simultaneously defined parameters
     are mutually exclusive."""
     pass
+
+class NonExistentDirectory(WafflesBaseException):
+    """Exception raised when an specified directory does
+    not exist."""

--- a/src/waffles/input_output/input_utils.py
+++ b/src/waffles/input_output/input_utils.py
@@ -982,5 +982,5 @@ def write_permission(directory_path: str) -> bool:
             )
         )
 
-    except PermissionError:
+    except (OSError, PermissionError):
         return False

--- a/src/waffles/input_output/input_utils.py
+++ b/src/waffles/input_output/input_utils.py
@@ -17,7 +17,7 @@ from typing import Union, List, Tuple, Optional
 
 from waffles.data_classes.Waveform import Waveform
 import waffles.utils.numerical_utils as wun
-from waffles.Exceptions import GenerateExceptionMessage
+import waffles.Exceptions as we
 
 
 def find_ttree_in_root_tfile(
@@ -58,20 +58,20 @@ def find_ttree_in_root_tfile(
     if library == 'uproot':
         if not isinstance(
                 file, uproot.ReadOnlyDirectory):
-            raise Exception(GenerateExceptionMessage(
+            raise Exception(we.GenerateExceptionMessage(
                 1,
                 'find_ttree_in_root_tfile()',
                 'Since the uproot library was specified, the input file'
                 ' must be of type uproot.ReadOnlyDirectory.'))
     elif library == 'pyroot':
         if not isinstance(file, ROOT.TFile):
-            raise Exception(GenerateExceptionMessage(
+            raise Exception(we.GenerateExceptionMessage(
                 2,
                 'find_ttree_in_root_tfile()',
                 'Since the pyroot library was specified, the input file '
                 'must be of type ROOT.TFile.'))
     else:
-        raise Exception(GenerateExceptionMessage(
+        raise Exception(we.GenerateExceptionMessage(
             3,
             'find_ttree_in_root_tfile()',
             f"The library '{library}' is not supported. Either 'uproot' "
@@ -91,7 +91,7 @@ def find_ttree_in_root_tfile(
                 break
 
     if TTree_name is None:
-        raise NameError(GenerateExceptionMessage(
+        raise NameError(we.GenerateExceptionMessage(
             4,
             'find_ttree_in_root_tfile()',
             f"There is no TTree with a name starting with '{TTree_pre_name}'."))
@@ -137,20 +137,20 @@ def find_tbranch_in_root_ttree(
 
     if library == 'uproot':
         if not isinstance(tree, uproot.TTree):
-            raise Exception(GenerateExceptionMessage(
+            raise Exception(we.GenerateExceptionMessage(
                 1,
                 'find_tbranch_in_root_ttree()',
                 'Since the uproot library was specified, '
                 'the input tree must be of type uproot.TTree.'))
     elif library == 'pyroot':
         if not isinstance(tree, ROOT.TTree):
-            raise Exception(GenerateExceptionMessage(
+            raise Exception(we.GenerateExceptionMessage(
                 2,
                 'find_tbranch_in_root_ttree()',
                 'Since the pyroot library was specified, '
                 'the input tree must be of type ROOT.TTree.'))
     else:
-        raise Exception(GenerateExceptionMessage(
+        raise Exception(we.GenerateExceptionMessage(
             3,
             'find_tbranch_in_root_ttree()',
             f"The library '{library}' is not supported. "
@@ -169,7 +169,7 @@ def find_tbranch_in_root_ttree(
                 break
 
     if TBranch_name is None:
-        raise NameError(GenerateExceptionMessage(
+        raise NameError(we.GenerateExceptionMessage(
             4,
             'find_tbranch_in_root_ttree()',
             "There is no TBranch with a name starting with"
@@ -251,7 +251,7 @@ def root_to_array_type_code(input: str) -> str:
     try:
         output = map[input]
     except KeyError:
-        raise ValueError(GenerateExceptionMessage(
+        raise ValueError(we.GenerateExceptionMessage(
             1,
             'root_to_array_type_code()',
             f"The given data type ({input}) is not recognized."))
@@ -309,7 +309,7 @@ def get_1d_array_from_pyroot_tbranch(
             branch_name,
             'pyroot')
     except NameError:
-        raise NameError(GenerateExceptionMessage(
+        raise NameError(we.GenerateExceptionMessage(
             1,
             'get_1d_array_from_pyroot_tbranch()',
             "There is no TBranch with a name starting with"
@@ -321,7 +321,7 @@ def get_1d_array_from_pyroot_tbranch(
         i_up_ = i_up
 
     if i_low < 0 or i_low >= i_up_ or i_up_ > branch.GetEntries():
-        raise Exception(GenerateExceptionMessage(
+        raise Exception(we.GenerateExceptionMessage(
             2,
             'get_1d_array_from_pyroot_tbranch()',
             f"The given range [{i_low}, {i_up_}) "

--- a/src/waffles/input_output/input_utils.py
+++ b/src/waffles/input_output/input_utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import array
 import numpy as np
 import uproot
+import tempfile
 
 try:
     import ROOT
@@ -946,3 +947,40 @@ def filepath_is_root_file_candidate(filepath: str) -> bool:
         return True
 
     return False
+
+def write_permission(directory_path: str) -> bool:
+    """This function gets the path to a directory, and checks
+    whether the running process has write permissions in such
+    directory.
+
+    Parameters
+    ----------
+    directory_path: str
+        Path to an existing directory. If the directory does
+        not exist, an exception is raised.
+
+    Returns
+    ----------
+    bool
+        True if the the running process has write permissions
+        in the specified directory. False if else."""
+
+    try:
+        with tempfile.TemporaryFile(
+            dir=directory_path
+        ):
+            pass
+
+        return True
+
+    except FileNotFoundError:
+        raise we.NonExistentDirectory(
+            we.GenerateExceptionMessage(
+                1,
+                'write_permission()',
+                f"The specified directory ({directory_path}) does not exist."
+            )
+        )
+
+    except PermissionError:
+        return False

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -188,7 +188,7 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
                                 subsample : int = 1,
                                 wvfm_count : int = 1e9,
                                 allowed_endpoints: Optional[list] = [],
-                                det : str = 'HD_PDS'
+                                det : str = 'HD_PDS',
                                 temporal_copy_directory: str = '/tmp',
                                 ) -> WaveformSet:
     """
@@ -273,7 +273,7 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
                 subsample,
                 wvfm_count,
                 allowed_endpoints,
-                det
+                det,
                 temporal_copy_directory=temporal_copy_directory
             )
 
@@ -297,7 +297,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                subsample : int = 1,
                                wvfm_count : int = 1e9,
                                allowed_endpoints: Optional[list] = [],
-                               det : str = 'HD_PDS'
+                               det : str = 'HD_PDS',
                                temporal_copy_directory: str = '/tmp',
                                ) -> WaveformSet:
     """

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -190,6 +190,7 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
                                 wvfm_count : int = 1e9,
                                 allowed_endpoints: Optional[list] = [],
                                 det : str = 'HD_PDS'
+                                temporal_copy_directory: str = '/tmp',
                                 ) -> WaveformSet:
     """
     Alternative initializer for a WaveformSet object that reads waveforms directly from hdf5 files.
@@ -237,6 +238,13 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
     det : str
         String that corresponds to the detector type.
         Examples: HD_PDS, VD_Membrane_PDS, VD_Cathode_PDS
+    temporal_copy_directory: str
+        It must be the path to an existing directory where the running
+        process has write permissions. This parameter only makes a difference
+        for those HDF5 files for which XRootD is used. For those ones, a copy
+        of the input HDF5 file is temporarily created in this directory. When
+        the goal WaveformSet has been finally created out of such temporal
+        HDF5-file copy, this copy is deleted from the specified directory.
     """
     if folderpath is not None:
 
@@ -267,6 +275,7 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
                 wvfm_count,
                 allowed_endpoints,
                 det
+                temporal_copy_directory=temporal_copy_directory
             )
 
         except Exception as error:

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -15,7 +15,6 @@ import fddetdataformats
 
 from multiprocessing import Pool, current_process, cpu_count
 
-import waffles.utils.check_utils as wuc
 from waffles.Exceptions import GenerateExceptionMessage
 from waffles.data_classes.Waveform import Waveform
 from waffles.data_classes.WaveformSet import WaveformSet


### PR DESCRIPTION
Some people reported an error reading `[ERROR] Local error: no space left on device:  (destination)` when using the `WaveformSet_from_hdf5_file` in batch mode, what was _probably_ due to the stack of files accumulated in the `/tmp` folder of the lxplus9 filesystem. Aiming to solve this, in this PR two functionalities are added:

- The copies of the HDF5 files brought from remote machines using XRootD are deleted once the WaveformSet has been created
- The location of this temporal-copy directory can be chosen using the new `temporal_copy_directory` parameter of `WaveformSet_from_hdf5_files()` (or `WaveformSet_from_hdf5_file()`). It is set to `/tmp` by default.

I have tested the new `WaveformSet_from_hdf5_file()` by comparing the created WaveformSet before and after the change, for run 27942 (in `root://xrootd.pic.es:1094/pnfs`). The first 10 read waveforms were identical before and after the change. I tested the new `WaveformSet_from_hdf5_files()` by reading 1000 waveforms from each one of the first three HDF5 listed for run 27633 (also in `root://xrootd.pic.es:1094/pnfs`). The created WaveformSet contains 3000 waveforms, as expected.

Since in this PR, the `waffles.input_output.input_utils` module is imported into `raw_hdf5_reader.py`, it is **important** that PR #80 is merged before this one. Otherwise, `raw_hdf5_reader.py` will be also affected by the ROOT NameError. Since the functionalities introduced `raw_hdf5_reader.py` are crucial, further tests before merging this PR are welcomed and encouraged.