### PR TITLE
Fix outdated references to the former `input` module

### DIFF
--- a/docs/10_Intro.md
+++ b/docs/10_Intro.md
@@ -39,7 +39,7 @@ Nevertheless, it is very important to keep some common rules not to harm others 
 2. **Data extraction**: the raw data is stored in `.hdf5` files. The optimal way of extracting the data is by running the following lines:
 
 ```python
-import waffles.input.raw_hdf5_reader as reader
+import waffles.input_output.raw_hdf5_reader as reader
 
 rucio_files = f"/eos/experiment/neutplatform/protodune/experiments/ProtoDUNE-II/PDS_Commissioning/waffles/1_rucio_paths/028602.txt"
 allfilepath = reader.get_filepaths_from_rucio(rucio_filepath)

--- a/docs/20_Scripts.md
+++ b/docs/20_Scripts.md
@@ -111,7 +111,7 @@ After that, every time you log in, you need to source ROOT, or you can edit ``en
 
 This script is used to convert the raw `.hdf5` files into `waffles` classes and save it locally in `.pkl` format. In order to run this script make sure you have a `waffles/data` folder to store the output files. In summary what this script does is:
 ```python
-import waffles.input.raw_hdf5_reader as reader
+import waffles.input_output.raw_hdf5_reader as reader
 
 rucio_files = f"/eos/experiment/neutplatform/protodune/experiments/ProtoDUNE-II/PDS_Commissioning/waffles/1_rucio_paths/028602.txt"
 allfilepath = reader.get_filepaths_from_rucio(rucio_filepath)

--- a/docs/examples/00_CheckData.ipynb
+++ b/docs/examples/00_CheckData.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "# Import the needed waffles classes/functions\n",
     "from waffles.plotting.plot import plot_ChannelWsGrid\n",
-    "import waffles.input.raw_root_reader as reader\n",
+    "import waffles.input_output.raw_root_reader as reader\n",
     "from waffles.data_classes.ChannelWsGrid import ChannelWsGrid\n",
     "\n",
     "# Import the needed waffles objects\n",

--- a/scripts/01_Process.py
+++ b/scripts/01_Process.py
@@ -1,7 +1,7 @@
 import click, pickle, inquirer
 
 from waffles.utils.utils import print_colored
-import waffles.input.raw_hdf5_reader as reader
+import waffles.input_output.raw_hdf5_reader as reader
 
 @click.command(help=f"\033[34mSave the WaveformSet object in a pickle file for easier loading.\n\033[0m")
 @click.option("--run",   default = None, help="Run number to process", type=str)

--- a/src/waffles/np04_analysis/tau_slow_convolution/makeultimatetemplate.py
+++ b/src/waffles/np04_analysis/tau_slow_convolution/makeultimatetemplate.py
@@ -2,7 +2,7 @@
 
 from waffles.data_classes.WaveformSet import WaveformSet
 from waffles.data_classes.Waveform import Waveform
-from waffles.input.pickle_file_reader import WaveformSet_from_pickle_file
+from waffles.input_output.pickle_file_reader import WaveformSet_from_pickle_file
 from waffles.np04_data.tau_slow_runs.load_runs_csv import ReaderCSV
 from extract_selection import Extractor
 import argparse

--- a/src/waffles/np04_analysis/tau_slow_convolution/scripts/makeultimatetemplate.py
+++ b/src/waffles/np04_analysis/tau_slow_convolution/scripts/makeultimatetemplate.py
@@ -2,7 +2,7 @@
 
 from waffles.data_classes.WaveformSet import WaveformSet
 from waffles.data_classes.Waveform import Waveform
-from waffles.input.pickle_file_reader import WaveformSet_from_pickle_file
+from waffles.input_output.pickle_file_reader import WaveformSet_from_pickle_file
 from waffles.np04_data.tau_slow_runs.load_runs_csv import ReaderCSV
 from extract_selection import Extractor
 import argparse

--- a/test/wtest_hdf5_reader.py
+++ b/test/wtest_hdf5_reader.py
@@ -1,6 +1,6 @@
 import pickle
 import re
-import waffles.input.raw_hdf5_reader as reader
+import waffles.input_output.raw_hdf5_reader as reader
 
 rucio_filepath = "/eos/experiment/neutplatform/protodune/dune/hd-protodune/1a/ec/np04hd_raw_run030003_0000_dataflow0_datawriter_0_20241014T152553.hdf5"
 

--- a/test/wtest_hdf5_reader_2.py
+++ b/test/wtest_hdf5_reader_2.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 import re
-import waffles.input.raw_hdf5_reader as reader
+import waffles.input_output.raw_hdf5_reader as reader
 
 rucio_filepath = (
     "/eos/experiment/neutplatform/protodune/experiments/"


### PR DESCRIPTION
In commit 6dc245c3af927612e8f4f33a2ee8df85c45e39cc, the `input` module was renamed to `input_output`, but some of the import statements for such module were not updated accordingly. Some of the `.rst` files in `docs/` may still contain some outdated references, though.