### PR TITLE
Add the functionality to look for a ROOT Branch with an exact name

### DIFF
--- a/src/waffles/input_output/input_utils.py
+++ b/src/waffles/input_output/input_utils.py
@@ -333,7 +333,9 @@ def get_1d_array_from_pyroot_tbranch(
         branch, exact_branch_name = find_tbranch_in_root_ttree(
             tree,
             branch_name,
-            'pyroot')
+            'pyroot',
+            require_exact_match=require_exact_match
+        )
     except NameError:
         raise NameError(we.GenerateExceptionMessage(
             1,
@@ -498,27 +500,37 @@ def __build_waveforms_list_from_root_file_using_uproot(
     adcs_branch, _ = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'adcs',
-        'uproot')
+        'uproot',
+        require_exact_match=False
+    )
 
     channel_branch, _ = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'channel',
-        'uproot')
+        'uproot',
+        require_exact_match=False
+    )
 
     timestamp_branch, _ = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'timestamp',
-        'uproot')
+        'uproot',
+        require_exact_match=False
+    )
     
     daq_timestamp_branch, _ = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'daq_timestamp',
-        'uproot')
+        'uproot',
+        require_exact_match=False
+    )
 
     record_branch, _ = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'record',
-        'uproot')
+        'uproot',
+        require_exact_match=False
+    )
 
     # Using a list comprehension here is slightly slower than a for loop
     # (97s vs 102s for 5% of wvfs of a 809 MB file running on lxplus9)
@@ -715,7 +727,9 @@ def __build_waveforms_list_from_root_file_using_pyroot(
     _, adcs_branch_exact_name = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'adcs',
-        'pyroot')
+        'pyroot',
+        require_exact_match=False
+    )
     adcs_address = ROOT.std.vector('short')()
     bulk_data_tree.SetBranchAddress(adcs_branch_exact_name,
                                     adcs_address)
@@ -723,7 +737,9 @@ def __build_waveforms_list_from_root_file_using_pyroot(
     _, channel_branch_exact_name = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'channel',
-        'pyroot')
+        'pyroot',
+        require_exact_match=False
+    )
 
     channel_address = array.array(
         root_to_array_type_code('S'),
@@ -736,7 +752,9 @@ def __build_waveforms_list_from_root_file_using_pyroot(
     _, timestamp_branch_exact_name = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'timestamp',
-        'pyroot')
+        'pyroot',
+        require_exact_match=False
+    )
 
     timestamp_address = array.array(
         root_to_array_type_code('l'),
@@ -749,7 +767,9 @@ def __build_waveforms_list_from_root_file_using_pyroot(
     _, daq_timestamp_branch_exact_name = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'daq_timestamp',
-        'pyroot')
+        'pyroot',
+        require_exact_match=False
+    )
     
     daq_timestamp_address = array.array(
         root_to_array_type_code('l'),
@@ -762,7 +782,9 @@ def __build_waveforms_list_from_root_file_using_pyroot(
     _, record_branch_exact_name = find_tbranch_in_root_ttree(
         bulk_data_tree,
         'record',
-        'pyroot')
+        'pyroot',
+        require_exact_match=False
+    )
 
     record_address = array.array(
         root_to_array_type_code('i'),
@@ -876,12 +898,17 @@ def __read_metadata_from_root_file_using_uproot(
     run_branch, _ = find_tbranch_in_root_ttree(
         meta_data_tree,
         'run',
-        'uproot')
+        'uproot',
+        require_exact_match=False
+    )
 
     ticks_to_nsec_branch, _ = find_tbranch_in_root_ttree(
         meta_data_tree,
         'ticks_to_nsec',
-        'uproot')
+        'uproot',
+        require_exact_match=False
+    )
+        
     run = int(run_branch.array()[0])
 
     ticks_to_nsec = float(ticks_to_nsec_branch.array()[0])
@@ -917,12 +944,16 @@ def __read_metadata_from_root_file_using_pyroot(
     _, run_branch_exact_name = find_tbranch_in_root_ttree(
         meta_data_tree,
         'run',
-        'pyroot')
+        'pyroot',
+        require_exact_match=False
+    )
 
     _, ticks_to_nsec_branch_exact_name = find_tbranch_in_root_ttree(
         meta_data_tree,
         'ticks_to_nsec',
-        'pyroot')
+        'pyroot',
+        require_exact_match=False
+    )
     
     run_address = array.array(
         root_to_array_type_code('i'),

--- a/src/waffles/input_output/input_utils.py
+++ b/src/waffles/input_output/input_utils.py
@@ -290,15 +290,20 @@ def get_1d_array_from_pyroot_tbranch(
     branch_name: str,
     i_low: int = 0,
     i_up: Optional[int] = None,
-    ROOT_type_code: str = 'S'
+    ROOT_type_code: str = 'S',
+    require_exact_match: bool = True
 ) -> np.ndarray:
     """This function returns a 1D numpy array containing the
-    values of the branch whose name starts with the string
+    values of the branch whose name matches the string
     given to the 'branch_name' parameter in the given ROOT
     TTree object. The values are taken from the entries
     of the TTree object whose iterator values are in the
     range [i_low, i_up). I.e. the lower (resp. upper) bound
-    is inclusive (resp. exclsive).
+    is inclusive (resp. exclusive). The required
+    matching between the given branch_name and the
+    branch whose data is returned, might be exact or not,
+    depending on the input given to the 'require_exact_match'
+    parameter.
 
     Parameters
     ----------
@@ -306,7 +311,7 @@ def get_1d_array_from_pyroot_tbranch(
         The ROOT TTree object where to look for the TBranch
     branch_name: str
         The string which the name of the TBranch object
-        must start with
+        must match to some extent
     i_low: int
         The inclusive lower bound of the range of entries
         to be read from the branch. It must be non-negative.
@@ -323,6 +328,13 @@ def get_1d_array_from_pyroot_tbranch(
         The data type of the branch to be read. The valid
         values can be checked in the docstring of the
         root_to_array_type_code() function.
+    require_exact_match: bool
+        If True, then the name of the TBranch whose
+        data is returned, must exactly match the string
+        given to the 'branch_name' parameter. If False,
+        then the first TBranch found whose name starts
+        with the given identifier is the one whose data
+        will be returned.
 
     Returns
     ----------
@@ -337,11 +349,16 @@ def get_1d_array_from_pyroot_tbranch(
             require_exact_match=require_exact_match
         )
     except NameError:
-        raise NameError(we.GenerateExceptionMessage(
-            1,
-            'get_1d_array_from_pyroot_tbranch()',
-            "There is no TBranch with a name starting with"
-            f" '{branch_name}' in the given tree."))
+        raise NameError(
+            we.GenerateExceptionMessage(
+                1,
+                'get_1d_array_from_pyroot_tbranch()',
+                "There is no TBranch with a name "+
+                ("matching" if require_exact_match
+                else "starting with")+
+                f" '{branch_name}' in the given tree."
+            )
+        )
     
     if i_up is None:
         i_up_ = branch.GetEntries()

--- a/src/waffles/input_output/raw_root_reader.py
+++ b/src/waffles/input_output/raw_root_reader.py
@@ -435,7 +435,9 @@ def WaveformSet_from_root_file(
             is_fullstream_branch_name,
             i_low=wf_start, 
             i_up=wf_stop,
-            ROOT_type_code='O')
+            ROOT_type_code='O',
+            require_exact_match=False
+        )
 
     aux = np.where(is_fullstream_array)[0] if read_full_streaming_data \
     else np.where(np.logical_not(is_fullstream_array))[0]

--- a/src/waffles/input_output/raw_root_reader.py
+++ b/src/waffles/input_output/raw_root_reader.py
@@ -409,7 +409,9 @@ def WaveformSet_from_root_file(
     wii.find_tbranch_in_root_ttree(
         bulk_data_tree,
         'is_fullstream',
-        library)
+        library,
+        require_exact_match=False
+    )
 
     aux = is_fullstream_branch.num_entries \
     if library == 'uproot' \


### PR DESCRIPTION
Functions `find_ttree_in_root_tfile()` and `find_tbranch_in_root_ttree()` of the `waffles.input_output.input_utils` module looked for an object whose name started with a certain prefix. This was introduced in the first place to bypass the ';i' suffixes added by ROOT to `TTree` objects names. Some `TTree` objects coming from the beam contain `TBranch` objects called 'P' and 'Pressure1', making it impossible for the `find_tbranch_in_root_ttree()` function to distinguish both branches in some cases (depending on the branches ordering). On top of this, ROOT may not add these kind of suffixes to `TBranch` objects, which is another reason to add the functionality to require an exact name matching in the `find_tbranch_in_root_ttree()` function.