### PR TITLE
Also prevent HDF5 deletion if the specified `wvfm_count` is reached

### DIFF
--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -299,7 +299,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                allowed_endpoints: Optional[list] = [],
                                det : str = 'HD_PDS',
                                temporal_copy_directory: str = '/tmp',
-                               erase_filepath : bool = True
+                               erase_temporal_copy: bool = True
                                ) -> WaveformSet:
     """
     Alternative initializer for a WaveformSet object that reads waveforms directly from hdf5 files.
@@ -348,8 +348,11 @@ def WaveformSet_from_hdf5_file(filepath : str,
         temporarily created in this directory. When the WaveformSet to
         return has been finally created out of such temporal HDF5-file copy,
         this copy is deleted from the specified directory.
-    erase_filepath: bool
-        it's true by default; if false, the file will be preserved.
+    erase_temporal_copy: bool
+        This parameter only makes a difference if XRootD is used, i.e. if
+        a temporal local copy of the target HDF5 file is created. If True,
+        (resp. False), then this temporal copy will (resp. will not) be
+        deleted after the WaveformSet object has been created.
     """
 
     if "/eos" not in filepath and "/nfs" not in filepath and "/afs" not in filepath:
@@ -380,8 +383,8 @@ def WaveformSet_from_hdf5_file(filepath : str,
             )
 
     else:
-        if erase_filepath:
-            erase_filepath = False
+        if erase_temporal_copy:
+            erase_temporal_copy = False
 
     h5_file = HDF5RawDataFile(filepath)
     run_date   = h5_file.get_attribute('creation_timestamp')
@@ -491,7 +494,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                     minimum_length
                                 )
 
-                        if erase_filepath:
+                        if erase_temporal_copy:
                             os.remove(filepath)
                         return WaveformSet(*waveforms)
                     
@@ -505,6 +508,6 @@ def WaveformSet_from_hdf5_file(filepath : str,
                 0,
                 minimum_length
             )
-    if erase_filepath :
+    if erase_temporal_copy:
         os.remove(filepath)
     return WaveformSet(*waveforms)

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -190,6 +190,7 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
                                 allowed_endpoints: Optional[list] = [],
                                 det : str = 'HD_PDS',
                                 temporal_copy_directory: str = '/tmp',
+                                erase_temporal_copy: bool = True
                                 ) -> WaveformSet:
     """
     Alternative initializer for a WaveformSet object that reads waveforms directly from hdf5 files.
@@ -244,6 +245,12 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
         of the input HDF5 file is temporarily created in this directory. When
         the goal WaveformSet has been finally created out of such temporal
         HDF5-file copy, this copy is deleted from the specified directory.
+    erase_temporal_copy: bool
+        This parameter only makes a difference for filepaths for which XRootD
+        is used, i.e. for filepaths for which a temporal local copy of the
+        target HDF5 file is created. If True, (resp. False), then the temporal
+        copies created for such filepaths will (resp. will not) be deleted
+        after its WaveformSet object has been created.
     """
     if folderpath is not None:
 
@@ -274,7 +281,8 @@ def WaveformSet_from_hdf5_files(filepath_list : List[str] = [],
                 wvfm_count,
                 allowed_endpoints,
                 det,
-                temporal_copy_directory=temporal_copy_directory
+                temporal_copy_directory=temporal_copy_directory,
+                erase_temporal_copy=erase_temporal_copy
             )
 
         except Exception as error:

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -364,6 +364,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
                 shlex.split(f"xrdcp {filepath} {temporal_copy_directory}"),
                 shell=False
             )
+            fUsedXRootD = True
 
             filepath = os.path.join(
                 temporal_copy_directory,
@@ -383,8 +384,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
             )
 
     else:
-        if erase_temporal_copy:
-            erase_temporal_copy = False
+        fUsedXRootD = False
 
     h5_file = HDF5RawDataFile(filepath)
     run_date   = h5_file.get_attribute('creation_timestamp')
@@ -494,7 +494,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                     minimum_length
                                 )
 
-                        if erase_temporal_copy:
+                        if fUsedXRootD and erase_temporal_copy:
                             os.remove(filepath)
                         return WaveformSet(*waveforms)
                     
@@ -508,6 +508,6 @@ def WaveformSet_from_hdf5_file(filepath : str,
                 0,
                 minimum_length
             )
-    if erase_temporal_copy:
+    if fUsedXRootD and erase_temporal_copy:
         os.remove(filepath)
     return WaveformSet(*waveforms)

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -491,7 +491,8 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                     minimum_length
                                 )
 
-                        os.remove(filepath)
+                        if erase_filepath:
+                            os.remove(filepath)
                         return WaveformSet(*waveforms)
                     
     if truncate_wfs_to_minimum:


### PR DESCRIPTION
In commit 8dd6844f5ff2941aba596cd0545444eb5a134ef5 of this PR , a bug is fixed - the change introduced in commit af16f3762bf9949e640eec9fe9f12dce3aa8efb0 did not cover the case where the number of read waveforms reaches the limit set by the user using the `wvfm_count` parameter. This was probably due to the fact that the `WaveformSet_from_hdf5_file()` function has two ways of returning a `WaveformSet`, which can be probably merged into just one with some refactoring in the near future.

The `WaveformSet_from_hdf5_file()` function has been tested to work as expected after this changes, testing both input file-paths
- `root://xrootd.pic.es:1094/pnfs/pic.es/data/dune/RSE/hd-protodune/80/87/np04hd_raw_run027089_0000_dataflow0_datawriter_0_20240614T153210.hdf5`
- `/eos/experiment/neutplatform/protodune/dune/hd-protodune/23/be/np04hd_raw_run032079_0000_dataflow0_datawriter_0_20241025T022133.hdf5`

For both of them, all four combinations within `wvfm_count=100, 1e+9`; `erase_temporal_copy=True, False` have been tested.