### PR TITLE
Fix subsampling bug and reduce duplicated code in HDF5 reader

### DIFF
--- a/src/waffles/input_output/input_utils.py
+++ b/src/waffles/input_output/input_utils.py
@@ -1221,3 +1221,34 @@ def get_branch_address(
 
     
     return branch_address
+
+
+def __truncate_waveforms_to_minimum_length_in_WaveformSet(
+        waveform_list: List[Waveform]
+) -> None:
+    """This helper function truncates the adcs object of every
+    Waveform object in the given list, to the length of the
+    shortest adcs found in such list.
+
+    Parameters
+    ----------
+    waveform_list: List[Waveform]
+        The input waveforms list whose waveforms may be
+        truncated
+
+    Returns
+    ----------
+    None
+    """
+
+    minimum_length = np.array(
+        [len(wf.adcs) for wf in waveform_list]
+    ).min()
+
+    for wf in waveform_list:
+        wf._WaveformAdcs__slice_adcs(
+            0,
+            minimum_length
+        )
+
+    return

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -491,17 +491,10 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                                   starting_tick=0))
                         saved_wvfms += 1
                         if saved_wvfms >= wvfm_count:
-
                             if truncate_wfs_to_minimum:
-                                minimum_length = np.array(
-                                    [len(wf.adcs) for wf in waveforms]
-                                ).min()
-
-                                for wf in waveforms:
-                                    wf._WaveformAdcs__slice_adcs(
-                                        0,
-                                        minimum_length
-                                    )
+                                wiu.__truncate_waveforms_to_minimum_length_in_WaveformSet(
+                                    waveforms
+                                )
 
                             if fUsedXRootD and erase_temporal_copy:
                                 os.remove(filepath)
@@ -510,15 +503,10 @@ def WaveformSet_from_hdf5_file(filepath : str,
                     wvfm_index += 1
                     
     if truncate_wfs_to_minimum:
-        minimum_length = np.array(
-            [len(wf.adcs) for wf in waveforms]
-        ).min()
+        wiu.__truncate_waveforms_to_minimum_length_in_WaveformSet(
+            waveforms
+        )
 
-        for wf in waveforms:
-            wf._WaveformAdcs__slice_adcs(
-                0,
-                minimum_length
-            )
     if fUsedXRootD and erase_temporal_copy:
         os.remove(filepath)
     return WaveformSet(*waveforms)

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -423,6 +423,7 @@ def WaveformSet_from_hdf5_file(filepath : str,
     # print(f'total number of records = {len(records)}')
 
     wvfm_index = 0
+    saved_wvfms = 0
     for i, r in enumerate(tqdm(records)):
         pds_geo_ids = list(h5_file.get_geo_ids_for_subdetector(
             r, detdataformats.DetID.string_to_subdetector(det)))
@@ -488,23 +489,25 @@ def WaveformSet_from_hdf5_file(filepath : str,
                                                   # Open task: Implement the truncation of the Waveform
                                                   # objects at this level (reading from an HDF5 file)
                                                   starting_tick=0))
+                        saved_wvfms += 1
+                        if saved_wvfms >= wvfm_count:
+
+                            if truncate_wfs_to_minimum:
+                                minimum_length = np.array(
+                                    [len(wf.adcs) for wf in waveforms]
+                                ).min()
+
+                                for wf in waveforms:
+                                    wf._WaveformAdcs__slice_adcs(
+                                        0,
+                                        minimum_length
+                                    )
+
+                            if fUsedXRootD and erase_temporal_copy:
+                                os.remove(filepath)
+                            return WaveformSet(*waveforms)
+
                     wvfm_index += 1
-                    if wvfm_index >= wvfm_count:
-
-                        if truncate_wfs_to_minimum:
-                            minimum_length = np.array(
-                                [len(wf.adcs) for wf in waveforms]
-                            ).min()
-
-                            for wf in waveforms:
-                                wf._WaveformAdcs__slice_adcs(
-                                    0,
-                                    minimum_length
-                                )
-
-                        if fUsedXRootD and erase_temporal_copy:
-                            os.remove(filepath)
-                        return WaveformSet(*waveforms)
                     
     if truncate_wfs_to_minimum:
         minimum_length = np.array(

--- a/src/waffles/input_output/raw_root_reader.py
+++ b/src/waffles/input_output/raw_root_reader.py
@@ -480,14 +480,9 @@ def WaveformSet_from_root_file(
             verbose=verbose)
         
     if truncate_wfs_to_minimum:
-                
-        minimum_length = np.array([len(wf.adcs) for wf in waveforms]).min()
-
-        for wf in waveforms:
-            wf._WaveformAdcs__slice_adcs(
-                0,
-                minimum_length
-            )
+        wii.__truncate_waveforms_to_minimum_length_in_WaveformSet(
+            waveforms
+        )
 
     return WaveformSet(*waveforms)
 


### PR DESCRIPTION
In commit 6d2290dd5320e5b6702662d787989e28b27e571b , a bug regarding the `subsample` and `wvfm_count` parameter of the `WaveformSet_from_hdf5_file()` function was fixed. It has been tested by reading both input HDF5 files

- root://xrootd.pic.es:1094/pnfs/pic.es/data/dune/RSE/hd-protodune/80/87/np04hd_raw_run027089_0000_dataflow0_datawriter_0_20240614T153210.hdf5
- /eos/experiment/neutplatform/protodune/dune/hd-protodune/23/be/np04hd_raw_run032079_0000_dataflow0_datawriter_0_20241025T022133.hdf5

for `subsample=1,2,3` and checking that the subsampling works as expected for the first 10 waveforms. 

In the rest of the commits, the functionality of truncating all of the waveforms to the length of the shortest waveform in a given waveform set, is encapsulated in a function and used in both functions, `WaveformSet_from_hdf5_file()` and `WaveformSet_from_root_file()`. After all 4 commits, `WaveformSet_from_hdf5_file()` have been tested to work as expected for every combination in `subsample=1,3` and `wvfm_count=100, 1e+9`.