### PR TITLE
Add an example analysis and handle list input parameters

### DIFF
--- a/scripts/create_analysis_minimal_structure.sh
+++ b/scripts/create_analysis_minimal_structure.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Define the default verbosity
+verbose=true
+
+# Parse the arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -v|--verbose)
+            verbose=true
+            shift
+            ;;
+        -nv|--no-verbose)
+            verbose=false
+            shift
+            ;;
+        *)
+            echo "Use: $0 [-v|--verbose] [-nv|--no-verbose]"
+            exit 1
+            ;;
+    esac
+done
+
+# Get the path to the directory from which this script is being executed 
+current_dir=$(pwd)
+
+# Ask for confirmation
+echo "The minimal analysis structure will be created in $current_dir, continue? (yes/no): "
+read answer
+
+# Convert the answer to lower case
+lower_case_answer=$(echo "$answer" | tr '[:upper:]' '[:lower:]')
+
+# Check whether the script can proceed
+if [[ "$lower_case_answer" == "y" || "$lower_case_answer" == "yes" ]]; then
+    # Create the minimal analysis structure
+    mkdir -p "$current_dir/configs"
+    mkdir -p "$current_dir/output"
+    mkdir -p "$current_dir/data"
+    mkdir -p "$current_dir/scripts"
+    touch "$current_dir/steering.yml"
+    touch "$current_dir/utils.py"
+    touch "$current_dir/params.yml"
+    touch "$current_dir/imports.py"
+    touch "$current_dir/Analysis1.py"
+
+    # Show the message only if running with verbosity
+    if [[ "$verbose" == "true" ]]; then
+    	echo "The minimal analysis structure has been created in $current_dir"
+    fi
+else
+    echo "The action was canceled."
+fi

--- a/scripts/create_analysis_minimal_structure.sh
+++ b/scripts/create_analysis_minimal_structure.sh
@@ -38,11 +38,37 @@ if [[ "$lower_case_answer" == "y" || "$lower_case_answer" == "yes" ]]; then
     mkdir -p "$current_dir/output"
     mkdir -p "$current_dir/data"
     mkdir -p "$current_dir/scripts"
-    touch "$current_dir/steering.yml"
+
+    if [ -e "$current_dir/steering.yml" ]; then
+        echo "Warning: $current_dir/steering.yml already exists"
+    else
+	    printf "1:\n  name: \"Analysis1\"\n  parameters_file: \"params.yml\"\n  overwriting_parameters: \"\"" > $current_dir/steering.yml
+    fi
+
+    if [ -e "$current_dir/params.yml" ]; then
+        echo "Warning: $current_dir/params.yml already exists"
+    else
+	    printf "input_path: \"\"\noutput_path: \"output/\"" > $current_dir/params.yml
+    fi
+
+    if [ -e "$current_dir/imports.py" ]; then
+        echo "Warning: $current_dir/imports.py already exists"
+    else
+	    printf "from pydantic import Field\nfrom waffles.data_classes.WafflesAnalysis import WafflesAnalysis, BaseInputParams" > $current_dir/imports.py
+    fi
+
     touch "$current_dir/utils.py"
-    touch "$current_dir/params.yml"
-    touch "$current_dir/imports.py"
-    touch "$current_dir/Analysis1.py"
+
+    if [ -e "$current_dir/Analysis1.py" ]; then
+        echo "Warning: $current_dir/Analysis1.py already exists"
+    else
+        if [ -e "$current_dir/../example_analysis/Analysis1.py" ]; then
+            cp $current_dir/../example_analysis/Analysis1.py $current_dir/Analysis1.py
+        else
+            touch "$current_dir/Analysis1.py"
+            echo "Warning: The example analysis $current_dir/../example_analysis/Analysis1.py was not found. An empty $current_dir/Analysis1.py file was created."
+        fi
+    fi
 
     # Show the message only if running with verbosity
     if [[ "$verbose" == "true" ]]; then

--- a/src/waffles/core/utils.py
+++ b/src/waffles/core/utils.py
@@ -1,7 +1,7 @@
 import argparse
 import pathlib
 import yaml
-from typing import Optional
+from typing import Optional, List
 
 import waffles.Exceptions as we
 
@@ -1048,3 +1048,36 @@ def analysis_folder_meets_requirements():
         )
     
     return
+
+def split_comma_separated_string(
+        input_string: str,
+        separator: str = ','
+    ) -> List[str]:
+    """This function should work as a field_validator
+    for parameters of pydantic models which are
+    hinted as lists. To this end, this function
+    splits up the given string into a list of
+    strings using the given separator. If the
+    given input_string parameter is not an string,
+    then this function returns the input_string
+    parameter as it is defined by the user,
+    delegating the validation of the input to
+    pydantic.
+
+    Parameters
+    ----------
+    input_string: str
+        The string to be split
+    separator: str
+        The separator to be used to split the
+        input
+
+    Returns
+    ----------
+    List[str]
+    """
+    
+    if isinstance(input_string, str):
+        return input_string.split(separator)
+    else:
+        return input_string

--- a/src/waffles/np04_analysis/example_analysis/Analysis1.py
+++ b/src/waffles/np04_analysis/example_analysis/Analysis1.py
@@ -1,0 +1,208 @@
+from waffles.np04_analysis.example_analysis.imports import *
+
+class Analysis1(WafflesAnalysis):
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def get_input_params_model(
+        cls
+    ) -> type:
+        """Implements the WafflesAnalysis.get_input_params_model()
+        abstract method. Returns the InputParams class, which is a
+        Pydantic model class that defines the input parameters for
+        this example analysis.
+        
+        Returns
+        -------
+        type
+            The InputParams class, which is a Pydantic model class
+        """
+        
+        class InputParams(BaseInputParams):
+            """Validation model for the input parameters of the
+            example calibration.
+            """
+
+            runs: list[int] = Field(
+                ...,
+                description="Run numbers of the runs to be read",
+                example=[27906, 27907]
+            )
+
+            waveforms_per_run: int = Field(
+                ...,
+                description="The number of waveforms to read from "
+                "the first rucio filepath for each run",
+                example=500
+            )
+
+            correct_by_baseline: bool = Field(
+                default=True,
+                description="Whether the baseline of each waveform "
+                "is subtracted before computing the average waveform"
+            )
+
+            rucio_paths_directory: str = Field(
+                default="/eos/experiment/neutplatform/protodune/"
+                "experiments/ProtoDUNE-II/PDS_Commissioning/"
+                "waffles/1_rucio_paths",
+                description="The directory where the rucio paths are "
+                "stored, following this format: the file "
+                "'0<run_number>.txt' contains one rucio path per line."
+            )
+
+        return InputParams
+
+    def initialize(
+        self,
+        input_parameters: BaseInputParams
+    ) -> None:
+        """Implements the WafflesAnalysis.initialize() abstract
+        method. It defines the attributes of the Analysis1 class.
+        
+        Parameters
+        ----------
+        input_parameters : BaseInputParams
+            The input parameters for this analysis
+            
+        Returns
+        -------
+        None
+        """
+
+        # Save the input parameters into an Analysis1 attribute
+        # so that they can be accessed by the other methods
+        self.params = input_parameters
+
+        self.read_input_loop_1 = self.params.runs
+        self.read_input_loop_2 = [None,]
+        self.read_input_loop_3 = [None,]
+        self.analyze_loop = [None,]
+
+        self.wfset = None
+        self.output_data = None
+
+    def read_input(self) -> bool:
+        """Implements the WafflesAnalysis.read_input() abstract
+        method. For the current iteration of the read_input loop,
+        which fixes a run number, it reads the first
+        self.params.waveforms_per_run waveforms from the first rucio
+        path found for this run, and creates a WaveformSet out of them,
+        which is assigned to the self.wfset attribute.
+            
+        Returns
+        -------
+        bool
+            True if the method ends execution normally
+        """
+
+        print(
+            "In function Analysis1.read_input(): "
+            f"Now reading waveforms for run {self.read_input_itr_1} ..."
+        )
+
+        # Get the rucio filepaths for the current run
+        filepaths = reader.get_filepaths_from_rucio(
+            self.params.rucio_paths_directory+f"/0{self.read_input_itr_1}.txt"
+        )
+
+        # Try to read the first self.params.waveforms_per_run waveforms
+        # from the first rucio filepath found for the current run
+        self.wfset = reader.WaveformSet_from_hdf5_file(
+            filepaths[0],
+            read_full_streaming_data=False,
+            truncate_wfs_to_minimum=True,
+            nrecord_start_fraction=0.0,
+            nrecord_stop_fraction=1.0,
+            subsample=1,
+            wvfm_count=self.params.waveforms_per_run,
+            allowed_endpoints=[],
+            det='HD_PDS',
+            temporal_copy_directory='/tmp',
+            erase_temporal_copy=True
+        )
+
+        return True
+
+    def analyze(self) -> bool:
+        """Implements the WafflesAnalysis.analyze() abstract method.
+        It performs the analysis of the waveforms contained in the
+        self.wfset attribute, which consists of the following steps:
+
+        1. If self.params.correct_by_baseline is True, the baseline
+        for each waveform in self.wfset is computed and used in
+        the computation of the mean waveform.
+        2. A WaveformAdcs object is created which matches the mean
+        of the waveforms in self.wfset.
+        
+        Returns
+        -------
+        bool
+            True if the method ends execution normally
+        """
+
+        print(
+            "In function Analysis1.analyze(): "
+            f"Computing the mean waveform for {len(self.wfset)} "
+            f"waveforms of run {self.read_input_itr_1} ..."
+        )
+
+        # 1. Compute the baseline for each waveform in the WaveformSet
+        if self.params.correct_by_baseline:
+            baselines = [
+                utils.get_baseline(
+                    wf,
+                    lower_time_tick_for_median=0,
+                    upper_time_tick_for_median=100
+                ) for wf in self.wfset.waveforms
+            ]
+        else:
+            baselines = [
+                0. for _ in self.wfset.waveforms
+            ]
+
+        # 2. Compute the mean waveform
+        mean_adcs = np.mean(
+            np.array([
+                wf.adcs - baseline for wf, baseline in zip(
+                    self.wfset.waveforms, baselines
+                )
+            ]),
+            axis=0
+        )
+
+        self.output_data = WaveformAdcs(
+            16.,
+            mean_adcs,
+        )
+
+        return True
+
+    def write_output(self) -> bool:
+        """Implements the WafflesAnalysis.write_output() abstract
+        method. It saves the mean waveform, which is a WaveformAdcs
+        object, to a pickle file.
+
+        Returns
+        -------
+        bool
+            True if the method ends execution normally
+        """
+
+        output_filepath = f"{self.params.output_path}"\
+            f"/mean_waveform_run_{self.read_input_itr_1}.pkl"
+
+        print(
+            "In function Analysis1.write_output(): "
+            f"Saving the mean waveform to {output_filepath} ..."
+        )
+
+        with open(output_filepath, "wb") as file:
+            pickle.dump(
+                self.output_data,
+                file
+            )
+
+        return True

--- a/src/waffles/np04_analysis/example_analysis/Analysis1.py
+++ b/src/waffles/np04_analysis/example_analysis/Analysis1.py
@@ -145,7 +145,7 @@ class Analysis1(WafflesAnalysis):
 
         print(
             "In function Analysis1.analyze(): "
-            f"Computing the mean waveform for {len(self.wfset)} "
+            f"Computing the mean waveform for {len(self.wfset.waveforms)} "
             f"waveforms of run {self.read_input_itr_1} ..."
         )
 

--- a/src/waffles/np04_analysis/example_analysis/Analysis1.py
+++ b/src/waffles/np04_analysis/example_analysis/Analysis1.py
@@ -152,7 +152,7 @@ class Analysis1(WafflesAnalysis):
         # 1. Compute the baseline for each waveform in the WaveformSet
         if self.params.correct_by_baseline:
             baselines = [
-                utils.get_baseline(
+                wnu.get_baseline(
                     wf,
                     lower_time_tick_for_median=0,
                     upper_time_tick_for_median=100

--- a/src/waffles/np04_analysis/example_analysis/Analysis1.py
+++ b/src/waffles/np04_analysis/example_analysis/Analysis1.py
@@ -53,6 +53,11 @@ class Analysis1(WafflesAnalysis):
                 "'0<run_number>.txt' contains one rucio path per line."
             )
 
+            validate_items = field_validator(
+                "runs",
+                mode="before"
+            )(wcu.split_comma_separated_string)
+
         return InputParams
 
     def initialize(

--- a/src/waffles/np04_analysis/example_analysis/Analysis2.py
+++ b/src/waffles/np04_analysis/example_analysis/Analysis2.py
@@ -1,0 +1,191 @@
+from waffles.np04_analysis.example_analysis.imports import *
+
+class Analysis2(WafflesAnalysis):
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def get_input_params_model(
+        cls
+    ) -> type:
+        """Implements the WafflesAnalysis.get_input_params_model()
+        abstract method. Returns the InputParams class, which is a
+        Pydantic model class that defines the input parameters for
+        this example analysis.
+        
+        Returns
+        -------
+        type
+            The InputParams class, which is a Pydantic model class
+        """
+        
+        class InputParams(BaseInputParams):
+            """Validation model for the input parameters of the
+            example calibration.
+            """
+
+            prominence: float = Field(
+                ...,
+                description="Minimal prominence for a peak to "
+                "be detected",
+                example=20
+            )
+
+        return InputParams
+
+    def initialize(
+        self,
+        input_parameters: BaseInputParams
+    ) -> None:
+        """Implements the WafflesAnalysis.initialize() abstract
+        method. It defines the attributes of the Analysis2 class.
+        
+        Parameters
+        ----------
+        input_parameters : BaseInputParams
+            The input parameters for this analysis
+            
+        Returns
+        -------
+        None
+        """
+
+        # Save the input parameters into an Analysis2 attribute
+        # so that they can be accessed by the other methods
+        self.params = input_parameters
+
+        self.read_input_loop_1 = [None,]
+        self.read_input_loop_2 = [None,]
+        self.read_input_loop_3 = [None,]
+        self.analyze_loop = [None,]
+
+        self.wfs = {}
+        self.peaks = {}
+        self.output_data = None
+
+    def read_input(self) -> bool:
+        """Implements the WafflesAnalysis.read_input() abstract
+        method. It reads every pickle file in the path given by
+        self.params.input_path which contains a WaveformAdcs object,
+        and stores them in the self.wfs attribute, which is a
+        dictionary. They keys of the dictionary are the filenames
+        of the pickle files, and the values are the WaveformAdcs
+        objects read from the files.
+
+        Returns
+        -------
+        bool
+            True if the method ends execution normally
+        """
+
+        print(
+            "In function Analysis2.read_input(): "
+            f"Now reading waveforms from {self.params.input_path} ..."
+        )
+
+        for filename in os.listdir(self.params.input_path):
+            if filename.endswith('.pkl'):
+                filepath = os.path.join(
+                    self.params.input_path,
+                    filename
+                )
+                try:
+                    with open(filepath, 'rb') as file:
+                        self.wfs[filename] = pickle.load(file)
+
+                        print(
+                            "In function Analysis2.read_input(): "
+                            f"Succesfully loaded {filename}"
+                        )
+                except Exception as error_message:
+                    print(
+                        "In function Analysis2.read_input(): "
+                        f"Error loading {filename}: {error_message}"
+                    )
+
+        return True
+
+    def analyze(self) -> bool:
+        """Implements the WafflesAnalysis.analyze() abstract method.
+        It performs the analysis of the waveforms contained in the
+        self.wfs attribute, which, for each waveform wf in self.wfs,
+        consists of running scipy.signal.find_peaks(wf.adcs) with
+        the prominence parameter set to self.params.prominence. The
+        results are stored in the self.peaks attribute, which is a
+        dictionary. The keys of the dictionary are the filenames of
+        the pickle files, and the values are the results of the
+        scipy.signal.find_peaks() function.
+        
+        Returns
+        -------
+        bool
+            True if the method ends execution normally
+        """
+
+        for filename in self.wfs.keys():
+
+            print(
+                "In function Analysis2.analyze(): "
+                "Finding peaks for waveform coming "
+                f"from {filename}"
+            )
+
+            wf = self.wfs[filename]
+            peaks, _ = spsi.find_peaks(
+                wf.adcs,
+                prominence=self.params.prominence
+            )
+            self.peaks[filename] = peaks
+
+        return True
+
+    def write_output(self) -> bool:
+        """Implements the WafflesAnalysis.write_output() abstract
+        method. For each waveform in self.wfs, it saves a plot of
+        it together with its spotted peaks.
+
+        Returns
+        -------
+        bool
+            True if the method ends execution normally
+        """
+
+        for filename in self.wfs.keys():
+
+            fig, ax = plt.subplots()
+
+            ax.plot(
+                self.wfs[filename].adcs,
+            )
+
+            ax.scatter(
+                self.peaks[filename],
+                [self.wfs[filename].adcs[idx] for idx in self.peaks[filename]],
+                color='red',
+                marker='v',
+                s=100,
+                label='Spotted peaks'
+            )
+
+            ax.set_xlabel("Time tick")
+            ax.set_ylabel("ADC value")
+            fig.suptitle(f"Waveform coming from {filename}")
+            ax.legend()
+
+            output_filepath = f"{self.params.output_path}"\
+                f"/{filename[:-4]}.png"
+
+            print(
+                "In function Analysis2.write_output(): "
+                f"Saving the plotted mean waveform to {output_filepath} ..."
+            )
+
+            plt.savefig(
+                output_filepath,
+                format='png'
+            )
+
+            plt.close()
+
+        return True

--- a/src/waffles/np04_analysis/example_analysis/Analysis2.py
+++ b/src/waffles/np04_analysis/example_analysis/Analysis2.py
@@ -69,7 +69,7 @@ class Analysis2(WafflesAnalysis):
         method. It reads every pickle file in the path given by
         self.params.input_path which contains a WaveformAdcs object,
         and stores them in the self.wfs attribute, which is a
-        dictionary. They keys of the dictionary are the filenames
+        dictionary. The keys of the dictionary are the filenames
         of the pickle files, and the values are the WaveformAdcs
         objects read from the files.
 

--- a/src/waffles/np04_analysis/example_analysis/Analysis2.py
+++ b/src/waffles/np04_analysis/example_analysis/Analysis2.py
@@ -133,7 +133,8 @@ class Analysis2(WafflesAnalysis):
 
             wf = self.wfs[filename]
             peaks, _ = spsi.find_peaks(
-                wf.adcs,
+                # Find peaks over the inverted waveform
+                -1.*wf.adcs,
                 prominence=self.params.prominence
             )
             self.peaks[filename] = peaks
@@ -163,7 +164,7 @@ class Analysis2(WafflesAnalysis):
                 self.peaks[filename],
                 [self.wfs[filename].adcs[idx] for idx in self.peaks[filename]],
                 color='red',
-                marker='v',
+                marker='^',
                 s=100,
                 label='Spotted peaks'
             )

--- a/src/waffles/np04_analysis/example_analysis/imports.py
+++ b/src/waffles/np04_analysis/example_analysis/imports.py
@@ -3,8 +3,9 @@ import numpy as np
 import pickle
 from matplotlib import pyplot as plt
 from scipy import signal as spsi
-from pydantic import Field
+from pydantic import Field, field_validator
 from waffles.data_classes.WafflesAnalysis import WafflesAnalysis, BaseInputParams
 from waffles.data_classes.WaveformAdcs import WaveformAdcs
 import waffles.input_output.raw_hdf5_reader as reader
 import waffles.np04_analysis.example_analysis.utils as wnu
+import waffles.core.utils as wcu

--- a/src/waffles/np04_analysis/example_analysis/imports.py
+++ b/src/waffles/np04_analysis/example_analysis/imports.py
@@ -1,0 +1,8 @@
+import os
+import numpy as np
+import pickle
+from matplotlib import pyplot as plt
+from scipy import signal as spsi
+import waffles.input_output.WaveformAdcs as WaveformAdcs
+import waffles.input_output.raw_hdf5_reader as reader
+import waffles.np04_analysis.example_analysis.utils as utils

--- a/src/waffles/np04_analysis/example_analysis/imports.py
+++ b/src/waffles/np04_analysis/example_analysis/imports.py
@@ -3,6 +3,8 @@ import numpy as np
 import pickle
 from matplotlib import pyplot as plt
 from scipy import signal as spsi
-import waffles.input_output.WaveformAdcs as WaveformAdcs
+from pydantic import Field
+from waffles.data_classes.WafflesAnalysis import WafflesAnalysis, BaseInputParams
+from waffles.data_classes.WaveformAdcs import WaveformAdcs
 import waffles.input_output.raw_hdf5_reader as reader
 import waffles.np04_analysis.example_analysis.utils as utils

--- a/src/waffles/np04_analysis/example_analysis/imports.py
+++ b/src/waffles/np04_analysis/example_analysis/imports.py
@@ -7,4 +7,4 @@ from pydantic import Field
 from waffles.data_classes.WafflesAnalysis import WafflesAnalysis, BaseInputParams
 from waffles.data_classes.WaveformAdcs import WaveformAdcs
 import waffles.input_output.raw_hdf5_reader as reader
-import waffles.np04_analysis.example_analysis.utils as utils
+import waffles.np04_analysis.example_analysis.utils as wnu

--- a/src/waffles/np04_analysis/example_analysis/params.yml
+++ b/src/waffles/np04_analysis/example_analysis/params.yml
@@ -1,0 +1,10 @@
+input_path: ""
+output_path: "output/"
+
+runs:
+  - 27906
+  - 27907
+
+waveforms_per_run: 500
+correct_by_baseline: True
+rucio_paths_directory: "/eos/experiment/neutplatform/protodune/experiments/ProtoDUNE-II/PDS_Commissioning/waffles/1_rucio_paths"

--- a/src/waffles/np04_analysis/example_analysis/steering.yml
+++ b/src/waffles/np04_analysis/example_analysis/steering.yml
@@ -1,0 +1,8 @@
+1:
+  name: "Analysis1"
+  parameters_file: "params.yml"
+  overwriting_parameters: ""
+2:
+  name: "Analysis2"
+  parameters_file: ""
+  overwriting_parameters: "--input_path output/ --output_path output/ --prominence 10"

--- a/src/waffles/np04_analysis/example_analysis/steering.yml
+++ b/src/waffles/np04_analysis/example_analysis/steering.yml
@@ -1,7 +1,7 @@
 1:
   name: "Analysis1"
   parameters_file: "params.yml"
-  overwriting_parameters: ""
+  overwriting_parameters: "--runs 27906,27910"
 2:
   name: "Analysis2"
   parameters_file: ""

--- a/src/waffles/np04_analysis/example_analysis/utils.py
+++ b/src/waffles/np04_analysis/example_analysis/utils.py
@@ -1,0 +1,38 @@
+import numpy as np
+from waffles.data_classes.WaveformAdcs import WaveformAdcs
+
+def get_baseline(
+        WaveformAdcs_object: WaveformAdcs,
+        lower_time_tick_for_median: int = 0,
+        upper_time_tick_for_median: int = 100
+) -> float:
+    """This function returns the baseline of a WaveformAdcs object
+    by computing the median of the ADC values in the time range
+    defined by the inclusive limits [lower_time_tick_for_median, 
+    upper_time_tick_for_median].
+
+    Parameters
+    ----------
+    WaveformAdcs_object: WaveformAdcs
+        The baseline is computed for the data in the adcs attribute
+        of this WaveformAdcs object
+
+    lower_time_tick_for_median (resp. upper_time_tick_for_median): int
+        Iterator value for the time tick which is the inclusive lower
+        (resp. upper) limit of the time range in which the median is
+        computed.
+
+    Returns
+    ----------
+    baseline: float
+        The baseline of the WaveformAdcs object, which is computed
+        as the median of the ADC values in the defined time range.
+        """
+    
+    # For the sake of efficiency, no well-formedness checks for the
+    # time limits are performed here. The caller must ensure that
+    # the limits are well-formed.
+
+    return np.median(WaveformAdcs_object.adcs[
+        lower_time_tick_for_median:upper_time_tick_for_median
+    ])

--- a/src/waffles/np04_analysis/tau_slow_convolution/Analysis1.py
+++ b/src/waffles/np04_analysis/tau_slow_convolution/Analysis1.py
@@ -39,6 +39,13 @@ class Analysis1(WafflesAnalysis):
             baseline_finish_response: int = Field(...,          description="work in progress")
             baseline_minimum_frac:  float = Field(...,          description="work in progress")
 
+            validate_items = field_validator(
+                "channels",
+                "runlist",
+                "blacklist",
+                mode="before"
+            )(wcu.split_comma_separated_string)
+
         return InputParams
 
     ##################################################################

--- a/src/waffles/np04_analysis/tau_slow_convolution/Analysis2.py
+++ b/src/waffles/np04_analysis/tau_slow_convolution/Analysis2.py
@@ -34,6 +34,12 @@ class Analysis2(WafflesAnalysis):
             no_save:      bool = Field(...,          description="work in progress")
             scan:         int  = Field(...,          description="work in progress")
 
+            validate_items = field_validator(
+                "runs",
+                "channels",
+                mode="before"
+            )(wcu.split_comma_separated_string)
+
         return InputParams
 
     ##################################################################

--- a/src/waffles/np04_analysis/tau_slow_convolution/imports.py
+++ b/src/waffles/np04_analysis/tau_slow_convolution/imports.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pickle
 import os
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from waffles.data_classes.WaveformSet import WaveformSet
 from waffles.input_output.pickle_file_reader import WaveformSet_from_pickle_file
@@ -11,5 +11,6 @@ from waffles.data_classes.WafflesAnalysis import WafflesAnalysis as WafflesAnaly
 from waffles.np04_analysis.tau_slow_convolution.ConvFitter import ConvFitter
 
 from waffles.utils.baseline.baseline import SBaseline
+import waffles.core.utils as wcu
 
 


### PR DESCRIPTION
The changes introduced in this PR are:

- An script to recreate a minimal analysis structure (see `scripts/create_analysis_minimal_structure.sh`) is added
- Add an example analysis (see `src/waffles/np04_analysis/example_analysis`)
- Tools to interpret input values for list parameters are added, and used within the tau-slow-convolution analysis and the example analysis