### PR TITLE
Document the input arguments of `src/waffles/core/main.py`

### DIFF
--- a/src/waffles/core/utils.py
+++ b/src/waffles/core/utils.py
@@ -11,14 +11,24 @@ def add_arguments_to_parser(
     """This function defines the arguments that the main program
     should accept. The arguments are the following:
     
-    -s, --steering: str
-        Name of the steering file.
-    -a, --analysis: str
-        The name of the analysis class to be
-        executed
-    -p, --params: str
-        Name of the parameters file.
-    -v, --verbose: bool
+    [-s, --steering]: str
+        Name of the steering file. It should be a YAML
+        file which orders the different analysis stages 
+        and sets a parameters file for each stage. Note that 
+        this parameter is mutually exclusive with the [-a, 
+        --analysis] and [-p, --params] parameters.
+    [-a, --analysis]: str
+        The name of the analysis class to be executed. 
+        The '.py' extension may not be included. This parameter 
+        is meant for situtations where only one analysis stage 
+        should be run. Note that this parameter is mutually 
+        exclusive with the [-s, --steering] parameter."
+    [-p, --params]: str
+        Name of the parameters file. It should be a YAML
+        file which contains the parameters to be used. Note 
+        that this parameter is mutually exclusive with the [-s, 
+        --steering] parameter.
+    [-v, --verbose]: bool
         Whether to run with verbosity.
         
     Parameters
@@ -39,7 +49,9 @@ def add_arguments_to_parser(
         default=None,
         help="Name of the steering file. It should be a YAML"
         " file which orders the different analysis stages "
-        "and sets a parameters file for each stage."
+        "and sets a parameters file for each stage. Note that "
+        "this parameter is mutually exclusive with the [-a, "
+        "--analysis] and [-p, --params] parameters."
     )
 
     parser.add_argument(
@@ -48,7 +60,10 @@ def add_arguments_to_parser(
         type=str,
         default=None,
         help="The name of the analysis class to be executed. "
-        "The '.py' extension may not be included."
+        "The '.py' extension may not be included. This parameter "
+        "is meant for situtations where only one analysis stage "
+        "should be run. Note that this parameter is mutually "
+        "exclusive with the [-s, --steering] parameter." 
     )
 
     parser.add_argument(
@@ -56,7 +71,10 @@ def add_arguments_to_parser(
         "--params",
         type=str,
         default=None,
-        help="Name of the parameters file."
+        help="Name of the parameters file. It should be a YAML"
+        " file which contains the parameters to be used. Note "
+        "that this parameter is mutually exclusive with the [-s, "
+        "--steering] parameter."
     )
 
     parser.add_argument(

--- a/src/waffles/core/utils.py
+++ b/src/waffles/core/utils.py
@@ -122,10 +122,10 @@ def get_ordered_list_of_analyses(
             an steering file is used, then the analysis name
             comes from the value of the 'name' sub-key, for each
             analysis. If an steering file is not used, then the
-            analysis name comes from the value given to the -a,
-            --analysis argument, if such argument is defined.
+            analysis name comes from the value given to the [-a,
+            --analysis] argument, if such argument is defined.
             It is set to 'Analysis1' by default, if an steering
-            file is not used and the -a, --analysis argument
+            file is not used and the [-a, --analysis] argument
             is not defined.
         - parameters_file: str
             If it is a non-empty string, then is interpreted
@@ -136,7 +136,7 @@ def get_ordered_list_of_analyses(
             the value of the 'parameters_file' sub-key, for
             each analysis. If an steering file is not used,
             then the parameters-file name comes from the value
-            given to the -p, --params argument, if defined,
+            given to the [-p, --params] argument, if defined,
             or set to "" otherwise.
         - overwriting_parameters: str
             An string, in the format which is normally given
@@ -300,9 +300,9 @@ def use_steering_file(
     params: Optional[str]
 ) -> bool:
     """This function gets three of the arguments passed to the
-    waffles main program, namely steering (caught from -s, --steering),
-    analysis (caught from -a, --analysis) and params (caught from -p,
-    --params). This function raises a 
+    waffles main program, namely steering (caught from [-s, --steering]),
+    analysis (caught from [-a, --analysis]) and params (caught from [-p,
+    --params]). This function raises a 
     waffles.Exceptions.IncompatibleInput exception if the given input
     is not valid (meaning the given arguments are not compatible
     with each other). If the given input is valid, then the function
@@ -316,15 +316,15 @@ def use_steering_file(
     ----------
     steering: None or str
         The path to the steering file. The input given to this
-        parameter should be the input given to the -s, --steering
+        parameter should be the input given to the [-s, --steering]
         flag of the main program.
     analysis: None or str
         The name of the analysis class to be executed. The input
         given to this parameter should be the input given to the
-        -a, --analysis flag of the main program.
+        [-a, --analysis] flag of the main program.
     params: None or str
         The name of the parameters file. The input given to this
-        parameter should be the input given to the -p, --params
+        parameter should be the input given to the [-p, --params]
         flag of the main program.
 
     Returns
@@ -349,9 +349,9 @@ def use_steering_file(
                     1,
                     'use_steering_file()',
                     reason="The given input is not valid since the "
-                    "'steering' parameter (-s, --steering) was "
-                    "defined along with the 'analysis' (-a, --analysis)"
-                    " and/or 'params' (-p, --params) parameter. Note "
+                    "'steering' parameter ([-s, --steering]) was "
+                    "defined along with the 'analysis' ([-a, --analysis])"
+                    " and/or 'params' ([-p, --params]) parameter. Note "
                     "that the 'steering' parameter is mutually exclusive "
                     "with the 'analysis' parameter, and the 'params' "
                     "parameter."


### PR DESCRIPTION
This documentation is displayed when `src/waffles/core/main.py` is run with the [-h, --help] flag.