### PR TITLE
try-except h5_file.get_thr()

### DIFF
--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -366,8 +366,13 @@ def WaveformSet_from_hdf5_file(filepath: str,
             pds_geo_ids = list(h5_file.get_geo_ids_for_subdetector(
                 r, detdataformats.DetID.string_to_subdetector(det)
             ))
-            trig = h5_file.get_trh(r)
-
+            
+            try:
+                trig = h5_file.get_trh(r)
+            except Exception as e:
+                logger.warning(f"Corrupted fragment:\n {r}\n{gid}\nError: {e}")
+                continue
+            
             for gid in pds_geo_ids:
                 try:
                     frag = h5_file.get_frag(r, gid)


### PR DESCRIPTION
Add a try except statement to avoid blocking the reader when reading HDF5 files from the NP04 VGAIN scan that may contain corrupted fragments. 