### PR TITLE
fixes in fetch rucio replicas and raw hdf5 reader

### DIFF
--- a/scripts/fetch_rucio_replicas.py
+++ b/scripts/fetch_rucio_replicas.py
@@ -2,6 +2,10 @@ import os
 import subprocess
 import getpass
 import click
+from collections import defaultdict
+from urllib.parse import urlparse
+
+
 
 # -----------------------------------------------------------------------------
 # Configuration
@@ -18,6 +22,51 @@ REPLICA_PREFIXES = [
 # -----------------------------------------------------------------------------
 # Helper functions
 # -----------------------------------------------------------------------------
+
+def _choose_realm(pfn_lines: list[str]) -> tuple[str, list[str]]:
+    """
+    Decide which group of PFNs to keep, in the following order:
+
+        1. DUNE_CERN_EOS   (host contains "eospublic.cern.ch")
+        2. FNAL_DCACHE     (host contains "fndca1.fnal.gov")
+        3. Any other realm – except eosctapublic.cern.ch
+           (if *only* eosctapublic is present, raise RuntimeError)
+
+    Returns
+    -------
+    chosen_realm : str
+        The host[:port] that won the selection.
+    realm_lines  : list[str]
+        PFNs that belong to that realm.
+    """
+    # Group PFNs by realm
+    realm_to_lines: dict[str, list[str]] = defaultdict(list)
+    for ln in pfn_lines:
+        if "://" not in ln:
+            continue
+        host_port = urlparse(ln).netloc
+        realm_to_lines[host_port].append(ln)
+
+    # Preferred realms (sub-string match makes the port irrelevant)
+    priorities = ["eospublic.cern.ch", "fndca1.fnal.gov"]
+
+    # 1-2.  Try the preferred ones in order
+    for dom in priorities:
+        for realm, lines in realm_to_lines.items():
+            if dom in realm:
+                return realm, lines
+
+    # 3.  If the only realm is eosctapublic → abort
+    non_cta = [(r, l) for r, l in realm_to_lines.items()
+               if "eosctapublic.cern.ch" not in r]
+    if not non_cta:
+        raise RuntimeError(
+            "Only CASTOR replicas (eosctapublic.cern.ch) were found – aborting."
+        )
+
+    # Otherwise just pick the first acceptable realm
+    return non_cta[0]
+
 
 def is_rucio_active() -> bool:
     """Return ``True`` if the user's Rucio environment is already usable."""
@@ -120,23 +169,22 @@ def fetch_rucio_replicas(run_number: str, max_files: int) -> None:
     # ------------------------------------------------------------------
     # Keep only PFNs from the *first* realm (protocol+domain)
     # ------------------------------------------------------------------
-    first_realm = next(
-        (ln.split("/")[2] for ln in all_lines if "://" in ln), None
-    )
-    if first_realm is None:
-        print("\033[31mNo valid realm found in the Rucio output.\033[0m")
+    try:
+        chosen_realm, same_realm_lines = _choose_realm(all_lines)
+    except RuntimeError as err:
+        print(f"\033[31m{err}\033[0m")
         return
 
-    same_realm_lines = [ln for ln in all_lines if first_realm in ln]
     selected_lines = same_realm_lines[:max_files]
 
     with open(output_file, "w") as fh:
         fh.write("\n".join(selected_lines) + "\n")
 
     print(
-        f"\033[92mSaved {len(selected_lines)} PFNs (realm {first_realm}, prefix {used_prefix}) to {output_file}\033[0m"
+        f"\033[92mSaved {len(selected_lines)} PFNs "
+        f"(realm {chosen_realm}, prefix {used_prefix}) "
+        f"to {output_file}\033[0m"
     )
-
 
 # -----------------------------------------------------------------------------
 # CLI
@@ -159,4 +207,3 @@ def main(runs: str, max_files: int) -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -128,7 +128,7 @@ def get_inv_map_id(det):
             '113': [14]
         }
     elif det == 'VD_Membrane_PDS' or det == 'VD_Cathode_PDS':
-        map_id = {'107': [51]}
+        map_id = {'107': [701, 51]}
     else:
         raise ValueError(f"det '{det}' is not recognized.")
     inv_map_id = {v: k for k, vals in map_id.items() for v in vals}


### PR DESCRIPTION
1) Added the source ID 701 in the VD endpoint (needed for the runs from 36400 onwards)
2) Changed the fetch_rucio_replicas script to have preferences in taking the runs: if the run is in eos it takes it from there, otherwise it searches for other machines; if it davs it raises an exception. 