### PR TITLE
Fix script 08

### DIFF
--- a/scripts/08_np02vd_run_downloader_processor.py
+++ b/scripts/08_np02vd_run_downloader_processor.py
@@ -218,8 +218,6 @@ def main() -> None:
             if not rem:
                 logging.warning("run %d: no remote files", run)
                 continue
-            if not args.all_chunks:
-                rem = rem[:1]
             loc = download_all(sftp, rem, raw_dir / f"run{run:06d}")
             (list_dir / f"{run:06d}.txt").write_text(
                 "\n".join(p.as_posix() for p in loc) + "\n")

--- a/scripts/08_np02vd_run_downloader_processor.py
+++ b/scripts/08_np02vd_run_downloader_processor.py
@@ -179,7 +179,8 @@ def main() -> None:
                         format="%(levelname)s: %(message)s")
 
     runs = parse_run_list(args.runs)
-    out_root = Path(args.out).resolve()
+    cfg = json.load(open(args.config_template))
+    out_root = Path(cfg.get("output_dir", args.out)).resolve()
     raw_dir = out_root / "raw"
     list_dir = out_root / "raw_lists"
     processed_dir = out_root / "processed"
@@ -239,17 +240,17 @@ def main() -> None:
         logging.warning("Nothing to process; all runs already done.")
     else:
         # ── Build config for 07_save_structured_from_config.py ──────────────
-        cfg = json.load(open(args.config_template))
         detector = cfg.get("det")
         cfg.update(dict(
             runs=pending,
             rucio_dir=list_dir.as_posix(),
             output_dir=processed_dir.as_posix()))
-        tmp_cfg = out_root / "temp_config.json"
+        pathscripts=Path(__file__).resolve().parent
+        tmp_cfg = pathscripts / "temp_config.json"
         tmp_cfg.write_text(json.dumps(cfg, indent=4))
 
         logging.info("🚀 07_save_structured_from_config.py …")
-        subprocess.run(["python3", "07_save_structured_from_config.py",
+        subprocess.run(["python3", f"{pathscripts}/07_save_structured_from_config.py",
                         "--config", tmp_cfg.as_posix()], check=True)
 
     # ── Plot each run (new or existing) ─────────────────────────────────────

--- a/scripts/08_np02vd_run_downloader_processor.py
+++ b/scripts/08_np02vd_run_downloader_processor.py
@@ -169,10 +169,10 @@ def main() -> None:
     auth.add_argument("--kerberos", action="store_true")
     auth.add_argument("--ssh-key", help="Path to private key")
     ap.add_argument("--all-chunks", action="store_true")
-    ap.add_argument("--max-waveforms", type=int, default=100)
+    ap.add_argument("--max-waveforms", type=int, default=100, help="Maximum waveforms to be plotted")
     ap.add_argument("--config-template", default="config.json")
-    ap.add_argument("--headless", action="store_true")
-    ap.add_argument("-v", "--verbose", action="count", default=0)
+    ap.add_argument("--headless", action="store_true", help="Set it to save html plots instead of showing them")
+    ap.add_argument("-v", "--verbose", action="count", default=1)
     args = ap.parse_args()
 
     logging.basicConfig(level=max(10, 30 - 10*args.verbose),

--- a/src/waffles/input_output/raw_hdf5_reader.py
+++ b/src/waffles/input_output/raw_hdf5_reader.py
@@ -172,7 +172,7 @@ def filepath_is_hdf5_file_candidate(filepath: str) -> bool:
         return filepath.endswith((".hdf5", ".h5"))
 
     # 2) Otherwise we insist the file exists *and* ends with .h5/.hdf5
-    return os.path.isfile(filepath) and filepath.endswith((".hdf5", ".h5"))
+    return os.path.isfile(filepath) and filepath.endswith((".hdf5", ".h5", ".hdf5.copied", ".h5.copied"))
 
 
 def get_filepaths_from_rucio(rucio_filepath) -> list:


### PR DESCRIPTION
Minor fixes in script 08: 
- Allow to save in different directory
- Allow the script also to be called from any directory
- Save single file is now working

Behavior change on the script:
- Set default verbose to 1 (INFO, WARNING)
- now even if the files have been processed, you can recreate the html files.
- if headless is not passed, it does not run the analysis (also do not create 'plot' folders).
    - Otherwise, it is just a waste of time. In the future, if we have an actual workflow, we can profit from it